### PR TITLE
Add dependency hardening defaults

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,183 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/aptos/aptos_v2/scripts"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      javascript:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/aptos/examples/example_basic_read"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      javascript:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/aptos/on_demand"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      javascript:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/javascript/common"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      javascript:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/sail/sail-sdk"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      javascript:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/solana/javascript/on-demand"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      javascript:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/solana/rust/switchboard-on-demand"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      javascript:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: "/sail/sail-sdk"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      rust:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: "/sail/sail-sdk/native"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      rust:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: "/solana/rust/switchboard-on-demand"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      rust:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: "/solana/rust/switchboard-on-demand-client"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      rust:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: "/surge/switchboard-surge-core"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      rust:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: "/surge/switchboard-surge-oracle"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      rust:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,18 @@
+# Dependency and automation governance
+.github/dependabot.yml @tamlut-modnys
+.github/workflows/** @tamlut-modnys
+**/package.json @tamlut-modnys
+**/package-lock.json @tamlut-modnys
+**/pnpm-lock.yaml @tamlut-modnys
+**/yarn.lock @tamlut-modnys
+**/bun.lock @tamlut-modnys
+**/bun.lockb @tamlut-modnys
+**/requirements.txt @tamlut-modnys
+**/requirements.in @tamlut-modnys
+**/pyproject.toml @tamlut-modnys
+**/poetry.lock @tamlut-modnys
+**/uv.lock @tamlut-modnys
+**/go.mod @tamlut-modnys
+**/go.sum @tamlut-modnys
+**/Cargo.toml @tamlut-modnys
+**/Cargo.lock @tamlut-modnys

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,15 @@
+version: 2
+
+triggerPaths:
+  - "**/package.json"
+  - "**/package-lock.json"
+  - "**/pnpm-lock.yaml"
+  - "**/bun.lock"
+  - "**/bun.lockb"
+  - "**/Cargo.toml"
+  - "**/Cargo.lock"
+  - "**/pyproject.toml"
+  - "**/requirements*.txt"
+  - "**/poetry.lock"
+  - "**/go.mod"
+  - "**/go.sum"


### PR DESCRIPTION
## Summary
- add CODEOWNERS coverage for dependency manifests and lockfiles
- add weekly Dependabot version update config
- add Socket trigger paths for dependency-manifest and lockfile changes

## Follow-up
- install and authorize the Socket GitHub App so `socket.yml` becomes active
- enable required status checks for Socket on dependency-changing pull requests
