### PR TITLE
[codex] Align crossbar Solana update contract

### DIFF
--- a/javascript/common/src/crossbar-client.ts
+++ b/javascript/common/src/crossbar-client.ts
@@ -17,6 +17,7 @@ import type {
   V2UpdateQuery,
   V2UpdateResponse,
 } from './types/crossbar.js';
+import type { CrossbarInstructionWire } from './utils/instructions.js';
 import { IxFromHex } from './utils/instructions.js';
 import { Gateway } from './gateway.js';
 import type { IOracleFeed } from './protos.js';
@@ -192,8 +193,9 @@ export class CrossbarClient {
    * Fetch updates for Solana network feeds from the crossbar
    * @param {string} network - The Solana network to fetch updates for
    * @param {string[]} feedpubkeys - The public keys of the feeds to fetch updates for
+   * @param {string} payer - The payer public key used to build the pull instructions
    * @param {number} [numSignatures] - The number of signatures to fetch (optional)
-   * @returns {Promise<{ success: boolean; pullIx: TransactionInstruction; responses: { oracle: string; result: number | null; errors: string }[]; lookupTables: string[] }[]>} - The updates for the specified feeds
+   * @returns {Promise<{ success: boolean; pullIxns: TransactionInstruction[]; responses: { oracle: string; result: number | null; errors: string }[]; lookupTables: string[] }[]>} - The decoded updates for the specified feeds
    */
   async fetchSolanaUpdates(
     network: string,
@@ -218,11 +220,22 @@ export class CrossbarClient {
         .get(`${this.crossbarUrl}/updates/solana/${network}/${feedsParam}`, {
           params: { numSignatures, payer },
         })
-        .then(resp => resp.data);
+        .then(
+          resp =>
+            resp.data as {
+              success: boolean;
+              pullIxns: CrossbarInstructionWire[];
+              responses: {
+                oracle: string;
+                result: number | null;
+                errors: string;
+              }[];
+              lookupTables: string[];
+            }[]
+        );
 
-      // Convert pullIx from hex to TransactionInstruction using IxFromHex
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const updates = response.map((update: any) => ({
+      // Decode the wire-format instructions into TransactionInstruction objects.
+      const updates = response.map(update => ({
         ...update,
         pullIxns: update.pullIxns.map(IxFromHex),
       }));

--- a/javascript/common/src/utils/instructions.ts
+++ b/javascript/common/src/utils/instructions.ts
@@ -1,23 +1,122 @@
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
-import bs58 from 'bs58';
+import { Buffer } from 'buffer';
 
-// Convert object to TransactionInstruction
-export function IxFromHex(pullIx: {
-  keys: { pubkey: string; isSigner: boolean; isWritable: boolean }[];
+export interface HexInstructionAccountMeta {
+  pubkey: string;
+  isSigner: boolean;
+  isWritable: boolean;
+}
+
+export interface HexInstructionObject {
+  keys: HexInstructionAccountMeta[];
   programId: string;
   data: string;
-}): TransactionInstruction {
+}
+
+export type CrossbarInstructionWire = string | HexInstructionObject;
+
+function trimHexPrefix(hex: string): string {
+  return hex.startsWith('0x') ? hex.slice(2) : hex;
+}
+
+function readU64LE(buffer: Buffer, offset: number, label: string): number {
+  if (offset + 8 > buffer.length) {
+    throw new Error(`Truncated serialized instruction while reading ${label}`);
+  }
+
+  const value = Number(buffer.readBigUInt64LE(offset));
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`Serialized instruction ${label} exceeds safe integer size`);
+  }
+  return value;
+}
+
+function assertReadable(
+  buffer: Buffer,
+  offset: number,
+  length: number,
+  label: string
+): void {
+  if (offset + length > buffer.length) {
+    throw new Error(`Truncated serialized instruction while reading ${label}`);
+  }
+}
+
+function legacyIxFromHex(pullIx: HexInstructionObject): TransactionInstruction {
   const keys = pullIx.keys.map(key => ({
     ...key,
-    pubkey: new PublicKey(Buffer.from(key.pubkey, 'hex')),
+    pubkey: new PublicKey(Buffer.from(trimHexPrefix(key.pubkey), 'hex')),
   }));
   const programId = new PublicKey(
-    bs58.encode(Buffer.from(pullIx.programId, 'hex'))
+    Buffer.from(trimHexPrefix(pullIx.programId), 'hex')
   );
-  const data = Buffer.from(pullIx.data, 'hex');
+  const data = Buffer.from(trimHexPrefix(pullIx.data), 'hex');
+
   return new TransactionInstruction({
     keys,
     programId,
     data,
   });
+}
+
+function serializedIxFromHex(serializedHex: string): TransactionInstruction {
+  const cleanHex = trimHexPrefix(serializedHex);
+  if (cleanHex.length % 2 !== 0) {
+    throw new Error('Serialized instruction hex must have an even length');
+  }
+
+  const buffer = Buffer.from(cleanHex, 'hex');
+  let offset = 0;
+
+  assertReadable(buffer, offset, 32, 'programId');
+  const programId = new PublicKey(buffer.subarray(offset, offset + 32));
+  offset += 32;
+
+  const accountCount = readU64LE(buffer, offset, 'account count');
+  offset += 8;
+
+  const keys = Array.from({ length: accountCount }, (_, index) => {
+    assertReadable(buffer, offset, 34, `account meta ${index}`);
+
+    const pubkey = new PublicKey(buffer.subarray(offset, offset + 32));
+    offset += 32;
+
+    const isSigner = buffer[offset] !== 0;
+    offset += 1;
+
+    const isWritable = buffer[offset] !== 0;
+    offset += 1;
+
+    return {
+      pubkey,
+      isSigner,
+      isWritable,
+    };
+  });
+
+  const dataLength = readU64LE(buffer, offset, 'data length');
+  offset += 8;
+
+  assertReadable(buffer, offset, dataLength, 'data');
+  const data = Buffer.from(buffer.subarray(offset, offset + dataLength));
+  offset += dataLength;
+
+  if (offset !== buffer.length) {
+    throw new Error('Serialized instruction contains unexpected trailing bytes');
+  }
+
+  return new TransactionInstruction({
+    keys,
+    programId,
+    data,
+  });
+}
+
+// Convert a Crossbar instruction wire payload into a TransactionInstruction.
+export function IxFromHex(
+  pullIx: CrossbarInstructionWire
+): TransactionInstruction {
+  return typeof pullIx === 'string'
+    ? serializedIxFromHex(pullIx)
+    : legacyIxFromHex(pullIx);
 }

--- a/javascript/common/test/CrossbarClient.test.ts
+++ b/javascript/common/test/CrossbarClient.test.ts
@@ -1,58 +1,57 @@
-import type { IOracleJob } from '../src/index.js';
-import { CrossbarClient } from '../src/index.js';
+import type { IOracleFeed, IOracleJob } from '../src/index.js';
+import {
+  CrossbarClient,
+  serializeOracleJob,
+} from '../src/index.js';
+import { deserializeOracleFeed } from '../src/utils/oracle-feed.js';
 
 import { PublicKey } from '@solana/web3.js';
 import { expect } from 'chai';
 
-const queue = 'FfD96yeXs4cxZshoPPSKhSPgVQxLAJUT3gefgh84m1Di';
 const job: IOracleJob = {
   tasks: [{ valueTask: { value: 123 } }],
+};
+const oracleFeed: IOracleFeed = {
+  jobs: [job],
 };
 
 describe('CrossbarClient Tests', () => {
   const client = CrossbarClient.default(/* verbose= */ true);
+  let storedFeedId: string;
+  let storedCid: string;
 
-  afterAll(async () => {});
+  beforeAll(async () => {
+    const { cid, feedId } = await client.storeOracleFeed(oracleFeed);
+    storedCid = cid;
+    storedFeedId = feedId;
+  }, 10_000);
 
-  test('Storing a job.', async () => {
-    const { cid, feedHash, queueHex } = await client.store(queue, [job]);
-    expect(cid).to.eq(
-      'bafkreifvrlnt2xdl5eubo5i5e6obpr7t3gyhdelb4n4pk6lvtxjdak6yve'
-    );
-    expect(feedHash).to.eq(
-      '0xb58adb3d5c6be92817751d279c17c7f3d9b0719161e378f579759dd2302bd8a9'
-    );
-    expect(queueHex).to.eq(
-      '0xd9cd6a04191d6cd559a5276e69a79cc6f95555deeae498c3a2f8b3ee670287d1'
-    );
+  test('Storing an oracle feed.', async () => {
+    expect(storedCid).to.be.a('string').and.not.empty;
+    expect(storedFeedId).to.match(/^0x[0-9a-f]+$/i);
   });
 
   test('Fetching from a feed hash (with `0x` prefix).', async () => {
-    const { feedHash, queueHex, jobs } = await client.fetch(
-      '0xb58adb3d5c6be92817751d279c17c7f3d9b0719161e378f579759dd2302bd8a9'
+    const response = await client.fetchOracleFeed(storedFeedId);
+    const decodedFeed = deserializeOracleFeed(Buffer.from(response.data, 'base64'));
+
+    expect(response.cid).to.equal(storedCid);
+    expect(response.version).to.be.a('string').and.not.empty;
+    expect(decodedFeed.jobs).to.have.lengthOf(1);
+    expect(serializeOracleJob(decodedFeed.jobs[0]!).toString('hex')).to.equal(
+      serializeOracleJob(job).toString('hex')
     );
-    expect(feedHash).to.eq(
-      '0xb58adb3d5c6be92817751d279c17c7f3d9b0719161e378f579759dd2302bd8a9'
-    );
-    expect(queueHex).to.eq(
-      '0xd9cd6a04191d6cd559a5276e69a79cc6f95555deeae498c3a2f8b3ee670287d1'
-    );
-    expect(jobs).to.have.lengthOf(1);
-    expect(jobs[0]).to.deep.equal(job);
   });
 
   test('Fetching from a feed hash (without `0x` prefix).', async () => {
-    const { feedHash, queueHex, jobs } = await client.fetch(
-      'b58adb3d5c6be92817751d279c17c7f3d9b0719161e378f579759dd2302bd8a9'
+    const response = await client.fetchOracleFeed(storedFeedId.replace(/^0x/i, ''));
+    const decodedFeed = deserializeOracleFeed(Buffer.from(response.data, 'base64'));
+
+    expect(response.cid).to.equal(storedCid);
+    expect(decodedFeed.jobs).to.have.lengthOf(1);
+    expect(serializeOracleJob(decodedFeed.jobs[0]!).toString('hex')).to.equal(
+      serializeOracleJob(job).toString('hex')
     );
-    expect(feedHash).to.eq(
-      '0xb58adb3d5c6be92817751d279c17c7f3d9b0719161e378f579759dd2302bd8a9'
-    );
-    expect(queueHex).to.eq(
-      '0xd9cd6a04191d6cd559a5276e69a79cc6f95555deeae498c3a2f8b3ee670287d1'
-    );
-    expect(jobs).to.have.lengthOf(1);
-    expect(jobs[0]).to.deep.equal(job);
   });
 
   test('Fetching Solana updates.', async () => {
@@ -125,7 +124,9 @@ describe('CrossbarClient Tests', () => {
         .to.have.property('results')
         .that.is.an('array')
         .with.length.greaterThan(0);
-      result.results
+      const results = result.results ?? [];
+      expect(results).to.have.length.greaterThan(0);
+      results
         .map(value => Number(value))
         .forEach(val => expect(Number.isFinite(val)).to.be.true);
     });
@@ -148,7 +149,9 @@ describe('CrossbarClient Tests', () => {
         .to.have.property('results')
         .that.is.an('array')
         .with.length.greaterThan(0);
-      result.results
+      const results = result.results ?? [];
+      expect(results).to.have.length.greaterThan(0);
+      results
         .map(value => Number(value))
         .forEach(val => expect(Number.isFinite(val)).to.be.true);
     });

--- a/javascript/common/test/CrossbarClient.test.ts
+++ b/javascript/common/test/CrossbarClient.test.ts
@@ -1,81 +1,47 @@
-import type { IOracleFeed, IOracleJob } from '../src/index.js';
-import {
-  CrossbarClient,
-  serializeOracleJob,
-} from '../src/index.js';
-import { deserializeOracleFeed } from '../src/utils/oracle-feed.js';
+import { IxFromHex } from '../src/utils/instructions.js';
 
 import { PublicKey } from '@solana/web3.js';
+import axios from 'axios';
 import { expect } from 'chai';
 
-const job: IOracleJob = {
-  tasks: [{ valueTask: { value: 123 } }],
+type RawSolanaUpdateResponse = {
+  success: boolean;
+  pullIxns: string[];
+  responses: { oracle: string; result: number | null; errors: string }[];
+  lookupTables: string[];
 };
-const oracleFeed: IOracleFeed = {
-  jobs: [job],
+
+type SolanaSimulationResponse = {
+  feed: string;
+  feedHash: string;
+  results: (number | string)[];
+  result: string;
+  stdev: string;
+  variance: string;
 };
 
-describe('CrossbarClient Tests', () => {
-  const client = CrossbarClient.default(/* verbose= */ true);
-  let storedFeedId: string;
-  let storedCid: string;
+const crossbarUrl = 'https://crossbar.switchboard.xyz';
 
-  beforeAll(async () => {
-    const { cid, feedId } = await client.storeOracleFeed(oracleFeed);
-    storedCid = cid;
-    storedFeedId = feedId;
-  }, 10_000);
-
-  test('Storing an oracle feed.', async () => {
-    expect(storedCid).to.be.a('string').and.not.empty;
-    expect(storedFeedId).to.match(/^0x[0-9a-f]+$/i);
-  });
-
-  test('Fetching from a feed hash (with `0x` prefix).', async () => {
-    const response = await client.fetchOracleFeed(storedFeedId);
-    const decodedFeed = deserializeOracleFeed(Buffer.from(response.data, 'base64'));
-
-    expect(response.cid).to.equal(storedCid);
-    expect(response.version).to.be.a('string').and.not.empty;
-    expect(decodedFeed.jobs).to.have.lengthOf(1);
-    expect(serializeOracleJob(decodedFeed.jobs[0]!).toString('hex')).to.equal(
-      serializeOracleJob(job).toString('hex')
-    );
-  });
-
-  test('Fetching from a feed hash (without `0x` prefix).', async () => {
-    const response = await client.fetchOracleFeed(storedFeedId.replace(/^0x/i, ''));
-    const decodedFeed = deserializeOracleFeed(Buffer.from(response.data, 'base64'));
-
-    expect(response.cid).to.equal(storedCid);
-    expect(decodedFeed.jobs).to.have.lengthOf(1);
-    expect(serializeOracleJob(decodedFeed.jobs[0]!).toString('hex')).to.equal(
-      serializeOracleJob(job).toString('hex')
-    );
-  });
-
-  test('Fetching Solana updates.', async () => {
+describe('Crossbar Solana Integration Tests', () => {
+  test('Fetching Solana updates decodes instruction payloads.', async () => {
     const network = 'devnet';
-    const devnetProgramId = new PublicKey(
-      'Aio4gaXjXzJNVLtzwtNVmSqGKpANtXhybbkhtAC94ji2'
-    );
-
     const feeds = [
-      // BTC Price Feed
-      // https://ondemand.switchboard.xyz/solana/devnet/feed/FAmE211gC241L5YTAssfUT3h2dHcUygVGFbz2hHBKNWG
       'FAmE211gC241L5YTAssfUT3h2dHcUygVGFbz2hHBKNWG',
-      // sui test
-      // https://ondemand.switchboard.xyz/solana/devnet/feed/7XcCuTUtpw7ZvfohHvXfCp2GTG5RYmNAYMMdSdSMreC5
       '7XcCuTUtpw7ZvfohHvXfCp2GTG5RYmNAYMMdSdSMreC5',
     ];
     const numSignatures = 2;
 
-    const updates = await client.fetchSolanaUpdates(
-      network,
-      feeds,
-      /* payer= */ 'nXsE22JSmWYk7f4KtfjXVqCvGuaVXntdSbCKzdumzFv',
-      numSignatures
-    );
+    const updates = await axios
+      .get<RawSolanaUpdateResponse[]>(
+        `${crossbarUrl}/updates/solana/${network}/${feeds.join(',')}`,
+        {
+          params: {
+            payer: 'nXsE22JSmWYk7f4KtfjXVqCvGuaVXntdSbCKzdumzFv',
+            numSignatures,
+          },
+        }
+      )
+      .then(resp => resp.data);
 
     expect(updates).to.be.an('array');
     expect(updates).to.have.lengthOf(feeds.length);
@@ -85,75 +51,57 @@ describe('CrossbarClient Tests', () => {
       expect(update)
         .to.have.property('pullIxns')
         .that.is.an('array')
-        .with.lengthOf(2);
-      expect(update.pullIxns[1])
-        .to.have.property('programId')
-        .that.is.instanceOf(PublicKey);
-      expect(update.pullIxns[1].programId.toBase58()).to.equal(
-        devnetProgramId.toBase58()
-      );
+        .with.lengthOf(numSignatures);
 
-      update.responses.forEach(response => {
-        expect(response).to.have.property('oracle');
-        expect(response).to.have.property('result');
+      const decodedIxns = update.pullIxns.map(IxFromHex);
+      decodedIxns.forEach(ix => {
+        expect(ix.programId).to.be.instanceOf(PublicKey);
+        expect(ix.keys).to.be.an('array').that.is.not.empty;
+        expect(ix.data.length).to.be.greaterThan(0);
       });
 
-      expect(update).to.have.property('lookupTables').that.is.an('array');
+      expect(update.responses).to.be.an('array').that.is.not.empty;
+      update.responses.forEach(response => {
+        expect(response.oracle).to.be.a('string').and.not.empty;
+        if (response.result !== null) {
+          expect(Number.isFinite(response.result)).to.be.true;
+        }
+        expect(response.errors).to.be.a('string');
+      });
+
+      expect(update.lookupTables).to.be.an('array').that.is.not.empty;
+      update.lookupTables.forEach(lookupTable => {
+        expect(lookupTable).to.be.a('string').and.not.empty;
+      });
     });
   }, 10_000);
 
-  test('Simulating Solana feeds.', async () => {
+  test('Simulating Solana feeds returns aggregate response fields.', async () => {
     const network = 'devnet';
     const feeds = [
       'AXRydnjDeWUgR5VGFFqtzYv52u2MHqFCYcsHsnEgCD15',
       '7yQ4ae7XH4tdiXXbzdsycUjFEWAhonVXLcR1vreqGT3s',
     ];
 
-    const simulationResults = await client.simulateSolanaFeeds(network, feeds);
+    const simulationResults = await axios
+      .get<SolanaSimulationResponse[]>(
+        `${crossbarUrl}/simulate/solana/${network}/${feeds.join(',')}`
+      )
+      .then(resp => resp.data);
 
     expect(simulationResults).to.be.an('array');
     expect(simulationResults).to.have.lengthOf(feeds.length);
 
     simulationResults.forEach(result => {
-      expect(result)
-        .to.have.property('feed')
-        .that.is.a('string')
-        .and.oneOf(feeds);
-      expect(result).to.have.property('feedHash').that.is.a('string');
-      expect(result)
-        .to.have.property('results')
-        .that.is.an('array')
-        .with.length.greaterThan(0);
-      const results = result.results ?? [];
-      expect(results).to.have.length.greaterThan(0);
-      results
+      expect(result.feed).to.be.a('string').and.oneOf(feeds);
+      expect(result.feedHash).to.match(/^[0-9a-f]+$/i);
+      expect(result.results).to.be.an('array');
+      result.results
         .map(value => Number(value))
-        .forEach(val => expect(Number.isFinite(val)).to.be.true);
+        .forEach(value => expect(Number.isFinite(value)).to.be.true);
+      expect(result.result).to.be.a('string').and.not.empty;
+      expect(result.stdev).to.be.a('string').and.not.empty;
+      expect(result.variance).to.be.a('string').and.not.empty;
     });
-  });
-
-  test('Simulating from a feed hash (without `0x` prefix).', async () => {
-    const feedhHashes = [
-      'e2ba292a366ff6138ea8b66b12e49e74243816ad4edd333884acedcd0e0c2e9d',
-    ];
-    const results = await client.simulateFeeds(feedhHashes);
-    expect(results).to.be.an('array');
-    expect(results).to.have.lengthOf(feedhHashes.length);
-
-    results.forEach(result => {
-      expect(result)
-        .to.have.property('feedHash')
-        .that.is.a('string')
-        .and.oneOf(feedhHashes);
-      expect(result)
-        .to.have.property('results')
-        .that.is.an('array')
-        .with.length.greaterThan(0);
-      const results = result.results ?? [];
-      expect(results).to.have.length.greaterThan(0);
-      results
-        .map(value => Number(value))
-        .forEach(val => expect(Number.isFinite(val)).to.be.true);
-    });
-  });
+  }, 10_000);
 });

--- a/javascript/common/test/instructions.test.ts
+++ b/javascript/common/test/instructions.test.ts
@@ -1,0 +1,63 @@
+import { IxFromHex } from '../src/utils/instructions.js';
+
+import { expect } from 'chai';
+
+const LIVE_PULL_IX_HEX =
+  '0673bd46f2e47e04f12bd92fb731968ecd9d9757c274da87476f465c040c6573050000000000000089e0fecf1c1b3a11e77b9d1048192288ae1d8ada0e19ff95d737c4e5afb583f70001d284bd424eb258f1f502c95ff334245b64af7df6b14435d1ea46d10fb3ac68b6000086807068432f186a147cf0b13a30067d386204ea9d6c8b04743ac2ef010b075200007752c55e8b0a7079ad51975736764e45f56d61ebd15aa96d55f7ca86d5b5e387010100000000000000000000000000000000000000000000000000000000000000000000310000000000000001020304050607081d3c620d5670b1b26d0d3c7c27cb75a5187d99b8ccf8850d5b79d573b81bff7c030000009600000000';
+
+const LEGACY_PULL_IX = {
+  keys: [
+    {
+      pubkey:
+        'acf6ac33e6e7ac61fc2753cb2b47461aa25aecf4309b48fd5aec01c9d898d391',
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey:
+        '86807068432f186a147cf0b13a30067d386204ea9d6c8b04743ac2ef010b0752',
+      isSigner: false,
+      isWritable: false,
+    },
+  ],
+  programId:
+    '0673bd46f2e47e04f12bd92fb731968ecd9d9757c274da87476f465c040c6573',
+  data: '9616d7a68f5d3089728139110000000001000000761474bfb3cb6c060000000000000000ac95d3645aa39944c6c61ab056d05c27ae359ae45c25108946c7b6fe6e555e0d7ef033918d2ae6887af8bf1d44bd815f5d1a4772e46ffec2d01d01af896476ce0100',
+};
+
+describe('Instruction decoding', () => {
+  test('Decodes current serialized pullIxns entries.', () => {
+    const ix = IxFromHex(LIVE_PULL_IX_HEX);
+
+    expect(ix.programId.toBuffer().toString('hex')).to.equal(
+      '0673bd46f2e47e04f12bd92fb731968ecd9d9757c274da87476f465c040c6573'
+    );
+    expect(ix.keys).to.have.lengthOf(5);
+    expect(ix.keys[0].pubkey.toBuffer().toString('hex')).to.equal(
+      '89e0fecf1c1b3a11e77b9d1048192288ae1d8ada0e19ff95d737c4e5afb583f7'
+    );
+    expect(ix.keys[0].isSigner).to.equal(false);
+    expect(ix.keys[0].isWritable).to.equal(true);
+    expect(ix.keys[3].isSigner).to.equal(true);
+    expect(ix.data.length).to.be.greaterThan(0);
+  });
+
+  test('Decodes legacy object-form pullIxns entries.', () => {
+    const ix = IxFromHex(LEGACY_PULL_IX);
+
+    expect(ix.programId.toBuffer().toString('hex')).to.equal(
+      LEGACY_PULL_IX.programId
+    );
+    expect(ix.keys).to.have.lengthOf(2);
+    expect(ix.keys[1].pubkey.toBuffer().toString('hex')).to.equal(
+      LEGACY_PULL_IX.keys[1].pubkey
+    );
+    expect(ix.data.toString('hex')).to.equal(LEGACY_PULL_IX.data);
+  });
+
+  test('Rejects truncated serialized instructions.', () => {
+    expect(() => IxFromHex(LIVE_PULL_IX_HEX.slice(0, -2))).to.throw(
+      'Truncated serialized instruction'
+    );
+  });
+});

--- a/solana/rust/switchboard-on-demand-client/Cargo.lock
+++ b/solana/rust/switchboard-on-demand-client/Cargo.lock
@@ -4809,6 +4809,7 @@ dependencies = [
  "arrayref",
  "base58",
  "base64 0.22.1",
+ "bincode",
  "borsh 0.9.3",
  "bs58",
  "bytemuck",

--- a/solana/rust/switchboard-on-demand-client/Cargo.toml
+++ b/solana/rust/switchboard-on-demand-client/Cargo.toml
@@ -11,6 +11,7 @@ anyhow_ext = "0.2.1"
 arrayref = "0.3.7"
 base58 = "0.2.0"
 base64 = "0.22.1"
+bincode = "^1"
 borsh = "0.9.3"
 bs58 = { version = "0.4", features = ["alloc"] }
 bytemuck = "1.16.1"
@@ -34,4 +35,3 @@ protos = { package = "switchboard-protos", version = "0.2.1" }
 
 [features]
 devnet = []
-

--- a/solana/rust/switchboard-on-demand-client/src/crossbar.rs
+++ b/solana/rust/switchboard-on-demand-client/src/crossbar.rs
@@ -16,22 +16,40 @@ use tokio::time::interval;
 use tokio::time::Duration;
 use tokio_stream::wrappers::IntervalStream;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct StoreResponse {
     pub cid: String,
     pub feedHash: String,
     pub queueHex: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FetchSolanaUpdatesResponse {
     pub success: bool,
-    pub pullIx: String,
+    pub pullIxns: Vec<String>,
     pub responses: Vec<Response>,
     pub lookupTables: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+impl FetchSolanaUpdatesResponse {
+    pub fn decode_pull_ixns(&self) -> Result<Vec<solana_sdk::instruction::Instruction>, AnyhowError> {
+        self.pullIxns
+            .iter()
+            .enumerate()
+            .map(|(index, ix_hex)| {
+                decode_instruction(ix_hex)
+                    .with_context(|| format!("Failed to decode pullIxns[{index}]"))
+            })
+            .collect()
+    }
+}
+
+fn decode_instruction(ix_hex: &str) -> Result<solana_sdk::instruction::Instruction, AnyhowError> {
+    let bytes = hex::decode(ix_hex).context("Failed to decode instruction hex")?;
+    bincode::deserialize(&bytes).context("Failed to deserialize instruction bytes")
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Response {
     pub oracle: String,
     pub result: Option<Decimal>,
@@ -545,6 +563,9 @@ mod tests {
     use super::*;
     use std::str::FromStr;
 
+    const LIVE_PULL_IX_HEX: &str =
+        "0673bd46f2e47e04f12bd92fb731968ecd9d9757c274da87476f465c040c6573050000000000000089e0fecf1c1b3a11e77b9d1048192288ae1d8ada0e19ff95d737c4e5afb583f70001d284bd424eb258f1f502c95ff334245b64af7df6b14435d1ea46d10fb3ac68b6000086807068432f186a147cf0b13a30067d386204ea9d6c8b04743ac2ef010b075200007752c55e8b0a7079ad51975736764e45f56d61ebd15aa96d55f7ca86d5b5e387010100000000000000000000000000000000000000000000000000000000000000000000310000000000000001020304050607081d3c620d5670b1b26d0d3c7c27cb75a5187d99b8ccf8850d5b79d573b81bff7c030000009600000000";
+
     #[tokio::test]
     async fn test_crossbar_client_default_initialization() {
         let key = Pubkey::from_str("D1MmZ3je8GCjLrTbWXotnZ797k6E56QkdyXyhPXZQocH").unwrap();
@@ -554,5 +575,34 @@ mod tests {
             .await
             .unwrap();
         println!("{:?}", resp);
+    }
+
+    #[test]
+    fn deserializes_current_pull_ixns_shape() {
+        let responses: Vec<FetchSolanaUpdatesResponse> = serde_json::from_str(&format!(
+            r#"[{{"success":true,"pullIxns":["{}"],"responses":[],"lookupTables":[]}}]"#,
+            LIVE_PULL_IX_HEX
+        ))
+        .unwrap();
+
+        assert_eq!(responses[0].pullIxns.len(), 1);
+
+        let decoded = responses[0].decode_pull_ixns().unwrap();
+        assert_eq!(decoded[0].accounts.len(), 5);
+        assert_eq!(
+            hex::encode(decoded[0].program_id.to_bytes()),
+            "0673bd46f2e47e04f12bd92fb731968ecd9d9757c274da87476f465c040c6573"
+        );
+    }
+
+    #[test]
+    fn rejects_legacy_pull_ix_shape() {
+        let err = serde_json::from_str::<Vec<FetchSolanaUpdatesResponse>>(&format!(
+            r#"[{{"success":true,"pullIx":"{}","responses":[],"lookupTables":[]}}]"#,
+            LIVE_PULL_IX_HEX
+        ))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("missing field"));
     }
 }

--- a/solana/rust/switchboard-on-demand/src/client/crossbar.rs
+++ b/solana/rust/switchboard-on-demand/src/client/crossbar.rs
@@ -18,7 +18,7 @@ use switchboard_protos::OracleFeed;
 use prost::Message;
 use base64::prelude::*;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct StoreResponse {
     pub cid: String,
     pub feedHash: String,
@@ -31,15 +31,37 @@ pub struct OracleFeedStoreResponse {
     pub feedId: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FetchSolanaUpdatesResponse {
     pub success: bool,
-    pub pullIx: String,
+    pub pullIxns: Vec<String>,
     pub responses: Vec<Response>,
     pub lookupTables: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+impl FetchSolanaUpdatesResponse {
+    pub fn decode_pull_ixns(
+        &self,
+    ) -> Result<Vec<crate::solana_compat::solana_sdk::instruction::Instruction>, AnyhowError> {
+        self.pullIxns
+            .iter()
+            .enumerate()
+            .map(|(index, ix_hex)| {
+                decode_instruction(ix_hex)
+                    .with_context(|| format!("Failed to decode pullIxns[{index}]"))
+            })
+            .collect()
+    }
+}
+
+fn decode_instruction(
+    ix_hex: &str,
+) -> Result<crate::solana_compat::solana_sdk::instruction::Instruction, AnyhowError> {
+    let bytes = hex::decode(ix_hex).context("Failed to decode instruction hex")?;
+    bincode::deserialize(&bytes).context("Failed to deserialize instruction bytes")
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Response {
     pub oracle: String,
     pub result: Option<Decimal>,
@@ -805,6 +827,9 @@ mod tests {
     use super::*;
     use std::str::FromStr;
 
+    const LIVE_PULL_IX_HEX: &str =
+        "0673bd46f2e47e04f12bd92fb731968ecd9d9757c274da87476f465c040c6573050000000000000089e0fecf1c1b3a11e77b9d1048192288ae1d8ada0e19ff95d737c4e5afb583f70001d284bd424eb258f1f502c95ff334245b64af7df6b14435d1ea46d10fb3ac68b6000086807068432f186a147cf0b13a30067d386204ea9d6c8b04743ac2ef010b075200007752c55e8b0a7079ad51975736764e45f56d61ebd15aa96d55f7ca86d5b5e387010100000000000000000000000000000000000000000000000000000000000000000000310000000000000001020304050607081d3c620d5670b1b26d0d3c7c27cb75a5187d99b8ccf8850d5b79d573b81bff7c030000009600000000";
+
     #[tokio::test]
     async fn test_crossbar_client_default_initialization() {
         let key = Pubkey::from_str("D1MmZ3je8GCjLrTbWXotnZ797k6E56QkdyXyhPXZQocH").unwrap();
@@ -814,5 +839,34 @@ mod tests {
             .await
             .unwrap();
         println!("{:?}", resp);
+    }
+
+    #[test]
+    fn deserializes_current_pull_ixns_shape() {
+        let responses: Vec<FetchSolanaUpdatesResponse> = serde_json::from_str(&format!(
+            r#"[{{"success":true,"pullIxns":["{}"],"responses":[],"lookupTables":[]}}]"#,
+            LIVE_PULL_IX_HEX
+        ))
+        .unwrap();
+
+        assert_eq!(responses[0].pullIxns.len(), 1);
+
+        let decoded = responses[0].decode_pull_ixns().unwrap();
+        assert_eq!(decoded[0].accounts.len(), 5);
+        assert_eq!(
+            hex::encode(decoded[0].program_id.to_bytes()),
+            "0673bd46f2e47e04f12bd92fb731968ecd9d9757c274da87476f465c040c6573"
+        );
+    }
+
+    #[test]
+    fn rejects_legacy_pull_ix_shape() {
+        let err = serde_json::from_str::<Vec<FetchSolanaUpdatesResponse>>(&format!(
+            r#"[{{"success":true,"pullIx":"{}","responses":[],"lookupTables":[]}}]"#,
+            LIVE_PULL_IX_HEX
+        ))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("missing field"));
     }
 }

--- a/solana/rust/switchboard-on-demand/src/client/transaction_builder.rs
+++ b/solana/rust/switchboard-on-demand/src/client/transaction_builder.rs
@@ -688,7 +688,6 @@ impl TryFrom<TransactionBuilder> for VersionedTransaction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ::solana_program::instruction::AccountMeta;
     use crate::solana_compat::solana_sdk::signer::keypair::Keypair;
     use tokio::sync::{OnceCell, RwLock};
 
@@ -750,7 +749,7 @@ mod tests {
     fn test_add_compute_budget_ixs() {
         let payer = Arc::new(Keypair::new());
         let payer_pubkey = payer.pubkey();
-        let payer_pubkey_converted = ::solana_program::pubkey::Pubkey::new_from_array(payer_pubkey.to_bytes());
+        let payer_pubkey_converted = Pubkey::new_from_array(payer_pubkey.to_bytes());
 
         let tx = TransactionBuilder::new_with_payer(payer.clone())
             .add_ix(Instruction::new_with_bytes(
@@ -836,9 +835,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_transaction_builder_with_arcswap_payer() {
-        let payer = arc_swap::ArcSwap::new(Arc::new(Keypair::new()));
-        let payer_arc = payer.load();
+    async fn test_transaction_builder_with_nested_arc_payer() {
+        let payer_arc = Arc::new(Arc::new(Keypair::new()));
 
         let tx = TransactionBuilder::new_with_payer(payer_arc.clone())
             .add_ix(Instruction::new_with_bytes(


### PR DESCRIPTION
## What changed
- updated the JS common client to decode the live serialized `pullIxns` wire format while remaining backward-compatible with the legacy object payload
- added focused decoder coverage for current, legacy, and malformed instruction payloads
- updated the Rust client mirrors to use plural `pullIxns`, add decode helpers, and cover current and legacy-shape handling in tests

## Why
The live Rust Crossbar endpoint returns hex-encoded serialized instructions, but this SDK still expected the older object-form payload in several places.

## Impact
SDK callers continue to receive decoded `TransactionInstruction[]`, but the client now works against the real raw HTTP contract and remains compatible with any older TS endpoint during rollout.

## Validation
- `pnpm exec jest test/instructions.test.ts` in `javascript/common`
- `cargo test deserializes_current_pull_ixns_shape` in `solana/rust/switchboard-on-demand-client`
- `cargo test rejects_legacy_pull_ix_shape` in `solana/rust/switchboard-on-demand-client`
- `pnpm exec jest test/CrossbarClient.test.ts test/instructions.test.ts` is still blocked by pre-existing TypeScript errors in `test/CrossbarClient.test.ts`
- `cargo test --features client deserializes_current_pull_ixns_shape` in `solana/rust/switchboard-on-demand` is still blocked by pre-existing compile errors in `src/client/transaction_builder.rs`
