### PR TITLE
[codex] Split secp256k1 host features from SBF builds

### DIFF
--- a/solana/rust/switchboard-on-demand/Cargo.lock
+++ b/solana/rust/switchboard-on-demand/Cargo.lock
@@ -2684,14 +2684,11 @@ dependencies = [
  "arrayref",
  "base64 0.22.1",
  "digest 0.9.0",
- "hmac-drbg",
  "libsecp256k1-core 0.3.0",
  "libsecp256k1-gen-ecmult 0.3.0",
  "libsecp256k1-gen-genmult 0.3.0",
  "rand 0.8.5",
  "serde",
- "sha2 0.9.9",
- "typenum",
 ]
 
 [[package]]

--- a/solana/rust/switchboard-on-demand/Cargo.lock
+++ b/solana/rust/switchboard-on-demand/Cargo.lock
@@ -2684,11 +2684,14 @@ dependencies = [
  "arrayref",
  "base64 0.22.1",
  "digest 0.9.0",
+ "hmac-drbg",
  "libsecp256k1-core 0.3.0",
  "libsecp256k1-gen-ecmult 0.3.0",
  "libsecp256k1-gen-genmult 0.3.0",
  "rand 0.8.5",
  "serde",
+ "sha2 0.9.9",
+ "typenum",
 ]
 
 [[package]]

--- a/solana/rust/switchboard-on-demand/Cargo.toml
+++ b/solana/rust/switchboard-on-demand/Cargo.toml
@@ -38,14 +38,19 @@ pid_override = []
 ## Client functionality for off-chain interactions (Gateway, Crossbar, transaction builders).
 ## Uses Solana SDK v2 with anchor-client compatibility.
 ## Includes: RPC client, transaction building, oracle feeds, and Crossbar integration.
-client = ["anchor-lang", "tokio", "futures", "reqwest", "prost", "dashmap", "tokio-stream", "bs58", "hex", "base64", "serde_json", "switchboard-utils", "solana-v2", "dep:solana-account-decoder-v2", "dep:solana-client-v2", "dep:solana-sdk-v2", "dep:chrono", "dep:futures-util", "dep:spl-associated-token-account", "dep:tokio-tungstenite", "dep:url"]
+client = ["anchor-lang", "tokio", "futures", "reqwest", "prost", "dashmap", "tokio-stream", "bs58", "hex", "base64", "serde_json", "switchboard-utils", "solana-v2", "secp256k1-host", "dep:solana-account-decoder-v2", "dep:solana-client-v2", "dep:solana-sdk-v2", "dep:chrono", "dep:futures-util", "dep:spl-associated-token-account", "dep:tokio-tungstenite", "dep:url"]
 
 ## Alias for `client` feature - explicitly uses Solana SDK v2.
 client-v2 = ["client"]
 
 ## Client feature using Solana v3 crates.
 ## Uses v2 compat modules for types that haven't been published for v3 yet.
-client-v3 = ["tokio", "futures", "reqwest", "prost", "dashmap", "tokio-stream", "bs58", "hex", "base64", "serde_json", "switchboard-utils", "solana-v3", "dep:solana-account-decoder-v3", "dep:solana-client-v3", "dep:solana-sdk-v3", "dep:solana-sdk-v2"]
+client-v3 = ["tokio", "futures", "reqwest", "prost", "dashmap", "tokio-stream", "bs58", "hex", "base64", "serde_json", "switchboard-utils", "solana-v3", "secp256k1-host", "dep:solana-account-decoder-v3", "dep:solana-client-v3", "dep:solana-sdk-v3", "dep:solana-sdk-v2"]
+
+## Enables host-only secp256k1 functionality such as signing and std-backed helpers.
+## Keep this disabled for SBF/CPI builds; normal host cargo trees may still include
+## getrandom through Solana host-only dependencies even when SBF builds are safe.
+secp256k1-host = ["libsecp256k1/std", "libsecp256k1/hmac"]
 
 ## Configures the crate for Solana devnet deployment.
 devnet = []
@@ -104,8 +109,8 @@ solana-account-decoder-v2 = { package = "solana-account-decoder", version = ">=2
 solana-account-decoder-v3 = { package = "solana-account-decoder", version = ">=3", optional = true }
 solana-client-v2 = { package = "solana-client", version = ">=2,<3", optional = true }
 solana-client-v3 = { package = "solana-client", version = ">=3", optional = true }
-solana-program-v2 = { package = "solana-program", version = ">=2,<3", optional = true }
-solana-program-v3 = { package = "solana-program", version = ">=3", optional = true }
+solana-program-v2 = { package = "solana-program", version = ">=2,<3", default-features = false, features = ["borsh"], optional = true }
+solana-program-v3 = { package = "solana-program", version = ">=3", default-features = false, features = ["borsh"], optional = true }
 solana-sdk-v2 = { package = "solana-sdk", version = ">=2,<3", optional = true }
 solana-sdk-v3 = { package = "solana-sdk", version = ">=3", optional = true }
 spl-associated-token-account = { version = "6.0", optional = true }

--- a/solana/rust/switchboard-on-demand/Cargo.toml
+++ b/solana/rust/switchboard-on-demand/Cargo.toml
@@ -92,7 +92,7 @@ futures-util = { version = "0.3", optional = true }
 faster-hex = "0.10.0"
 futures = { version = "0.3.31", optional = true }
 hex = { version = "0.4", optional = true }
-libsecp256k1 = "0.7.1"
+libsecp256k1 = { version = "0.7.2", default-features = false, features = ["static-context"] }
 pinocchio = { version = "0.9.2", features = ["std"], optional = true }
 prost = { version = "0.13.1", optional = true }
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false, optional = true }

--- a/solana/rust/switchboard-on-demand/Cargo.toml
+++ b/solana/rust/switchboard-on-demand/Cargo.toml
@@ -38,19 +38,14 @@ pid_override = []
 ## Client functionality for off-chain interactions (Gateway, Crossbar, transaction builders).
 ## Uses Solana SDK v2 with anchor-client compatibility.
 ## Includes: RPC client, transaction building, oracle feeds, and Crossbar integration.
-client = ["anchor-lang", "tokio", "futures", "reqwest", "prost", "dashmap", "tokio-stream", "bs58", "hex", "base64", "serde_json", "switchboard-utils", "solana-v2", "secp256k1-host", "dep:solana-account-decoder-v2", "dep:solana-client-v2", "dep:solana-sdk-v2", "dep:chrono", "dep:futures-util", "dep:spl-associated-token-account", "dep:tokio-tungstenite", "dep:url"]
+client = ["anchor-lang", "tokio", "futures", "reqwest", "prost", "dashmap", "tokio-stream", "bs58", "hex", "base64", "serde_json", "switchboard-utils", "solana-v2", "dep:solana-account-decoder-v2", "dep:solana-client-v2", "dep:solana-sdk-v2", "dep:chrono", "dep:futures-util", "dep:spl-associated-token-account", "dep:tokio-tungstenite", "dep:url"]
 
 ## Alias for `client` feature - explicitly uses Solana SDK v2.
 client-v2 = ["client"]
 
 ## Client feature using Solana v3 crates.
 ## Uses v2 compat modules for types that haven't been published for v3 yet.
-client-v3 = ["tokio", "futures", "reqwest", "prost", "dashmap", "tokio-stream", "bs58", "hex", "base64", "serde_json", "switchboard-utils", "solana-v3", "secp256k1-host", "dep:solana-account-decoder-v3", "dep:solana-client-v3", "dep:solana-sdk-v3", "dep:solana-sdk-v2"]
-
-## Enables host-only secp256k1 functionality such as signing and std-backed helpers.
-## Keep this disabled for SBF/CPI builds; normal host cargo trees may still include
-## getrandom through Solana host-only dependencies even when SBF builds are safe.
-secp256k1-host = ["libsecp256k1/std", "libsecp256k1/hmac"]
+client-v3 = ["tokio", "futures", "reqwest", "prost", "dashmap", "tokio-stream", "bs58", "hex", "base64", "serde_json", "switchboard-utils", "solana-v3", "dep:solana-account-decoder-v3", "dep:solana-client-v3", "dep:solana-sdk-v3", "dep:solana-sdk-v2"]
 
 ## Configures the crate for Solana devnet deployment.
 devnet = []
@@ -120,3 +115,7 @@ tokio = { version = "^1.41", features = ["full", "tracing"], optional = true }
 tokio-stream = { version = ">=0.1.17", optional = true }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"], optional = true }
 url = { version = "2.5", optional = true }
+
+[target.'cfg(not(target_os = "solana"))'.dependencies]
+# Preserve host signing/std behavior without enabling host randomness paths in SBF builds.
+libsecp256k1 = { version = "0.7.2", default-features = false, features = ["std", "hmac"] }


### PR DESCRIPTION
## Summary

This keeps `libsecp256k1` minimal for Solana/SBF builds while preserving the existing host/off-chain signing behavior.

The final shape is:

- Keep the baseline dependency minimal: `default-features = false`, `features = ["static-context"]`.
- Enable `libsecp256k1/std` and `libsecp256k1/hmac` only through a non-Solana target-specific dependency: `cfg(not(target_os = "solana"))`.
- Avoid adding a new public Cargo feature just to restore host behavior.
- Pin `solana-program` v2/v3 dependencies to `default-features = false, features = ["borsh"]` so future Solana default-feature drift does not leak into SBF/CPI builds.
- Leave public Rust APIs unchanged, including `OracleAccountData::libsecp256k1_signer()`.

## Why

PR #12 was trying to stop SBF/CPI builds from pulling in host randomness paths through `libsecp256k1`, which can fail with `getrandom: target is not supported`.

The compatibility concern is that fully removing `std`/`hmac` from `libsecp256k1` can change host/client behavior, especially for signing-related helpers. This version avoids that by preserving host behavior automatically on non-Solana targets, while keeping the Solana target path minimal.

Normal host `cargo tree` output may still show `std`, `hmac`, `hmac-drbg`, `sha2 0.9`, `typenum`, or `getrandom`. That is expected now. The invariant is that the real Solana SBF build uses `target_os = "solana"`, does not enable the host-only dependency path, and succeeds.

## Verification

Ran inside the Codex container:

- `cargo tree --locked --no-default-features --features "cpi,solana-v3" -e features -i libsecp256k1@0.7.2`
  - Host target shows `std`/`hmac` by design because `cfg(not(target_os = "solana"))` applies.
- `cargo tree --locked --no-default-features --features "client-v3" -e features -i libsecp256k1@0.7.2`
  - Host target shows `static-context`, `std`, and `hmac`.
- `cargo check --locked --no-default-features --features "cpi,solana-v2"`
- `cargo check --locked --no-default-features --features "cpi,solana-v3"`
- `cargo check --locked --features client`
- Real downstream `cargo build-sbf` smoke test with `switchboard-on-demand = { default-features = false, features = ["cpi", "solana-v3"] }`
  - Passed.
  - No `getrandom: target is not supported` failure.
