### PR TITLE
[codex] Add SDK release notes mirror

### DIFF
--- a/SDK_RELEASE_NOTES.md
+++ b/SDK_RELEASE_NOTES.md
@@ -7,7 +7,7 @@ The newest release batch should stay at the top.
 
 ### `@switchboard-xyz/on-demand@3.10.4`
 
-Status: planned.
+Status: prepared; dry-run verified.
 
 - Fixed Solana network resolution so official Switchboard program IDs resolve to the correct cluster defaults.
 - Fixed randomness oracle eligibility so healthy pull oracles are not rejected only because `enable_gateway = 0`; `enable_pull_oracle` remains the relevant eligibility gate.
@@ -15,14 +15,14 @@ Status: planned.
 
 ### `switchboard-on-demand-client@0.6.0`
 
-Status: planned.
+Status: prepared; dry-run verified.
 
 - Updated the client crate for Solana 3.x crate compatibility.
 - Fixed release guardrail paths so crate packaging checks use the `solana/rust/switchboard-on-demand-client` mirror layout.
 
 ### `switchboard-on-demand@0.12.2`
 
-Status: planned.
+Status: prepared; dry-run verified.
 
 - Preserved Crossbar feed simulation results when building update instructions.
 - Fixed Sui result deserialization and removed noisy client logs.

--- a/SDK_RELEASE_NOTES.md
+++ b/SDK_RELEASE_NOTES.md
@@ -1,0 +1,29 @@
+# SDK Release Notes
+
+This file is the canonical release notes ledger for Switchboard SDK releases.
+The newest release batch should stay at the top.
+
+## 2026-06-08 Release Prep
+
+### `@switchboard-xyz/on-demand@3.10.4`
+
+Status: planned.
+
+- Fixed Solana network resolution so official Switchboard program IDs resolve to the correct cluster defaults.
+- Fixed randomness oracle eligibility so healthy pull oracles are not rejected only because `enable_gateway = 0`; `enable_pull_oracle` remains the relevant eligibility gate.
+- Includes the merged `sbv3#1015` randomness eligibility fix and smoke-test coverage.
+
+### `switchboard-on-demand-client@0.6.0`
+
+Status: planned.
+
+- Updated the client crate for Solana 3.x crate compatibility.
+- Fixed release guardrail paths so crate packaging checks use the `solana/rust/switchboard-on-demand-client` mirror layout.
+
+### `switchboard-on-demand@0.12.2`
+
+Status: planned.
+
+- Preserved Crossbar feed simulation results when building update instructions.
+- Fixed Sui result deserialization and removed noisy client logs.
+- Kept the SBF-safe `libsecp256k1` feature split for Solana builds.

--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -32,11 +32,13 @@ ${GITHUB_PR_BODY}
 '''
     ),
     origin_files = glob([
+      "SDK_RELEASE_NOTES.md",
       "javacsript/**",
       "solana/**"
     ]),
     # Only affect files under these paths in the destination
     destination_files = glob([
+      "SDK_RELEASE_NOTES.md",
       "javascript/on-demand/**",
       "javascript/common/**",
       "rust/switchboard-on-demand/**",


### PR DESCRIPTION
## Summary

- Add the mirrored public `SDK_RELEASE_NOTES.md` ledger at the switchboard-sdk repo root.
- Include root `SDK_RELEASE_NOTES.md` in the switchboard-sdk -> sbv3 Copybara mapping so contributor PRs can sync release-note edits back to sbv3.

## Verification

- `git diff --check`
- Confirmed the release notes file is present at repo root.
- Confirmed the release notes content is byte-identical with the canonical sbv3 branch.
- Confirmed the root notes file is outside npm/crate package directories and is not referenced by package manifests.

## Related

Canonical sbv3 PR: https://github.com/switchboard-xyz/sbv3/pull/1018