### PR TITLE
[codex] Prepare three SDK releases

### DIFF
--- a/SDK_RELEASE_NOTES.md
+++ b/SDK_RELEASE_NOTES.md
@@ -3,6 +3,10 @@
 This file is the canonical release notes ledger for Switchboard SDK releases.
 The newest release batch should stay at the top.
 
+## Release Prep Checklist
+
+- Before publishing, confirm each release-note version matches the canonical `sbv3` manifest version, the final `switchboard-sdk` release-branch manifest version, and the latest published registry version.
+
 ## 2026-06-08 Release Prep
 
 ### `@switchboard-xyz/on-demand@3.10.4`
@@ -20,10 +24,11 @@ Status: prepared; dry-run verified.
 - Updated the client crate for Solana 3.x crate compatibility.
 - Fixed release guardrail paths so crate packaging checks use the `solana/rust/switchboard-on-demand-client` mirror layout.
 
-### `switchboard-on-demand@0.12.2`
+### `switchboard-on-demand@0.13.0`
 
 Status: prepared; dry-run verified.
 
+- Bumped the crate release target to `0.13.0` for the Pinocchio `AccountView` migration and compatible Pinocchio `0.11.x` dependency range.
 - Preserved Crossbar feed simulation results when building update instructions.
 - Fixed Sui result deserialization and removed noisy client logs.
 - Kept the SBF-safe `libsecp256k1` feature split for Solana builds.

--- a/SDK_RELEASE_NOTES.md
+++ b/SDK_RELEASE_NOTES.md
@@ -7,7 +7,7 @@ The newest release batch should stay at the top.
 
 ### `@switchboard-xyz/on-demand@3.10.4`
 
-Status: planned.
+Status: prepared; dry-run verified.
 
 - Fixed Solana network resolution so official Switchboard program IDs resolve to the correct cluster defaults.
 - Fixed randomness oracle eligibility so healthy pull oracles are not rejected only because `enable_gateway = 0`; `enable_pull_oracle` remains the relevant eligibility gate.
@@ -15,14 +15,14 @@ Status: planned.
 
 ### `switchboard-on-demand-client@0.6.0`
 
-Status: planned.
+Status: prepared; dry-run verified.
 
 - Updated the client crate for Solana 3.x crate compatibility.
 - Fixed release guardrail paths so crate packaging checks use the `solana/rust/switchboard-on-demand-client` mirror layout.
 
 ### `switchboard-on-demand@0.12.2`
 
-Status: planned.
+Status: prepared; dry-run verified.
 
 - Preserved Crossbar feed simulation results when building update instructions.
 - Fixed Sui result deserialization and removed noisy client logs.

--- a/SDK_RELEASE_NOTES.md
+++ b/SDK_RELEASE_NOTES.md
@@ -1,0 +1,29 @@
+# SDK Release Notes
+
+This file is the canonical release notes ledger for Switchboard SDK releases.
+The newest release batch should stay at the top.
+
+## 2026-06-08 Release Prep
+
+### `@switchboard-xyz/on-demand@3.10.4`
+
+Status: planned.
+
+- Fixed Solana network resolution so official Switchboard program IDs resolve to the correct cluster defaults.
+- Fixed randomness oracle eligibility so healthy pull oracles are not rejected only because `enable_gateway = 0`; `enable_pull_oracle` remains the relevant eligibility gate.
+- Includes the merged `sbv3#1015` randomness eligibility fix and smoke-test coverage.
+
+### `switchboard-on-demand-client@0.6.0`
+
+Status: planned.
+
+- Updated the client crate for Solana 3.x crate compatibility.
+- Fixed release guardrail paths so crate packaging checks use the `solana/rust/switchboard-on-demand-client` mirror layout.
+
+### `switchboard-on-demand@0.12.2`
+
+Status: planned.
+
+- Preserved Crossbar feed simulation results when building update instructions.
+- Fixed Sui result deserialization and removed noisy client logs.
+- Kept the SBF-safe `libsecp256k1` feature split for Solana builds.

--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -32,11 +32,13 @@ ${GITHUB_PR_BODY}
 '''
     ),
     origin_files = glob([
+      "SDK_RELEASE_NOTES.md",
       "javacsript/**",
       "solana/**"
     ]),
     # Only affect files under these paths in the destination
     destination_files = glob([
+      "SDK_RELEASE_NOTES.md",
       "javascript/on-demand/**",
       "javascript/common/**",
       "rust/switchboard-on-demand/**",

--- a/solana/javascript/on-demand/package.json
+++ b/solana/javascript/on-demand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchboard-xyz/on-demand",
-  "version": "3.10.1",
+  "version": "3.10.4",
   "description": "A Typescript client to interact with Switchboard On-Demand.",
   "license": "ISC",
   "main": "dist/cjs/index.js",
@@ -26,18 +26,21 @@
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "prepack": "pnpm build",
-    "test": "pnpm run test:authority-quote && pnpm run test:pull-feed-discriminators && pnpm run test:randomness-close-lut && pnpm run test:network-resolution",
+    "test": "pnpm run test:authority-quote && pnpm run test:pull-feed-discriminators && pnpm run test:randomness-close-lut && pnpm run test:network-resolution && pnpm run test:evm-randomness-oracle-selection && pnpm run test:solana-randomness-oracle-selection",
     "test:authority-quote": "pnpm exec tsx test/oracleQuote.authority.smoke.ts",
     "test:pull-feed-discriminators": "pnpm exec tsx test/pullFeed.discriminators.smoke.ts",
     "test:randomness-close-lut": "pnpm exec tsx test/randomness.closeLutIx.smoke.ts",
-    "test:network-resolution": "pnpm exec tsx test/networkResolution.test.ts"
+    "test:network-resolution": "pnpm exec tsx test/networkResolution.test.ts",
+    "test:evm-randomness-oracle-selection": "pnpm exec tsx test/evmRandomnessOracleSelection.smoke.ts",
+    "test:solana-randomness-oracle-selection": "pnpm exec tsx test/solanaRandomnessOracleSelection.smoke.ts"
   },
   "dependencies": {
     "@coral-xyz/anchor-31": "npm:@coral-xyz/anchor@0.31.1",
     "@isaacs/ttlcache": "^1.4.1",
+    "@noble/hashes": "^1.8.0",
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
-    "@switchboard-xyz/common": "^5.8.1",
+    "@switchboard-xyz/common": "^5.8.2",
     "@switchboard-xyz/common-legacy": "^1.1.0",
     "axios": "^1.9",
     "bs58": "^6.0.0",

--- a/solana/javascript/on-demand/pnpm-lock.yaml
+++ b/solana/javascript/on-demand/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@isaacs/ttlcache':
         specifier: ^1.4.1
         version: 1.4.1
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@solana/spl-token':
         specifier: ^0.4.14
         version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -21,8 +24,8 @@ importers:
         specifier: ^1.98.4
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@switchboard-xyz/common':
-        specifier: ^5.7.0
-        version: 5.8.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        specifier: ^5.8.2
+        version: 5.8.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@switchboard-xyz/common-legacy':
         specifier: ^1.1.0
         version: 1.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -62,7 +65,7 @@ importers:
         version: 0.1.0(@types/eslint@9.6.1)(gts@6.0.2(@types/eslint@9.6.1)(typescript@5.9.3))(ts-api-utils@2.5.0(typescript@5.9.3))(typescript@5.9.3)
       '@types/node':
         specifier: latest
-        version: 25.6.0
+        version: 25.9.2
       '@types/ws':
         specifier: ^8.18.0
         version: 8.18.1
@@ -98,7 +101,7 @@ importers:
         version: 1.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.6.0)
+        version: 29.7.0(@types/node@25.9.2)
       os-browserify:
         specifier: ^0.3.0
         version: 0.3.0
@@ -1267,8 +1270,8 @@ packages:
     resolution: {integrity: sha512-bKrzYxv8NohgEJgbZTrHP479p+rINT7fYbRtwk0hFBBqJTZC4aStq6BP9fjBi4ww2REM4pD2+692Lqc5VtSdsg==}
     engines: {node: '>=20'}
 
-  '@switchboard-xyz/common@5.8.1':
-    resolution: {integrity: sha512-r/rYci96PUqu72fcAdlYIVHaUTXs9dXI+VPQlpcbXCbCcDLHszXYxXlyesT1zdORW7JBiIcHJU3oiYyaDTG6MQ==}
+  '@switchboard-xyz/common@5.8.2':
+    resolution: {integrity: sha512-Wl2/pkOqbyku4fdOvO3lyai1VI0NfQtb+z/9dIgkh76M04+5PUyked44XTNo6GH4f92fZV9b3zoB4gW554Af9g==}
     engines: {node: '>=20'}
 
   '@the-ruby-group/rgts@0.1.0':
@@ -1323,8 +1326,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@25.9.2':
+    resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -1469,6 +1472,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -3746,8 +3750,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -3791,6 +3795,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -3909,6 +3914,11 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
@@ -4976,7 +4986,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -4989,14 +4999,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.6.0)
+      jest-config: 29.7.0(@types/node@25.9.2)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -5021,7 +5031,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -5039,7 +5049,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -5061,7 +5071,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -5131,7 +5141,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -5389,7 +5399,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@switchboard-xyz/common@5.8.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@switchboard-xyz/common@5.8.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       axios: 1.15.2
@@ -5400,6 +5410,7 @@ snapshots:
       decimal.js: 10.6.0
       js-sha256: 0.11.1
       protobufjs: 7.5.5
+      yaml: 2.9.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -5452,7 +5463,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -5468,7 +5479,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -5486,9 +5497,9 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.6.0':
+  '@types/node@25.9.2':
     dependencies:
-      undici-types: 7.19.2
+      undici-types: 7.24.6
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -5500,11 +5511,11 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -6217,13 +6228,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
-  create-jest@29.7.0(@types/node@25.6.0):
+  create-jest@29.7.0(@types/node@25.9.2):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.6.0)
+      jest-config: 29.7.0(@types/node@25.9.2)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -7235,7 +7246,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -7255,16 +7266,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@25.6.0):
+  jest-cli@29.7.0(@types/node@25.9.2):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.6.0)
+      create-jest: 29.7.0(@types/node@25.9.2)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.6.0)
+      jest-config: 29.7.0(@types/node@25.9.2)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -7274,7 +7285,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@25.6.0):
+  jest-config@29.7.0(@types/node@25.9.2):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -7299,7 +7310,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -7328,7 +7339,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -7338,7 +7349,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -7377,7 +7388,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -7412,7 +7423,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -7440,7 +7451,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -7486,7 +7497,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -7505,7 +7516,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -7514,23 +7525,23 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@25.6.0):
+  jest@29.7.0(@types/node@25.9.2):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.6.0)
+      jest-cli: 29.7.0(@types/node@25.9.2)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -7865,7 +7876,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.6.0
+      '@types/node': 25.9.2
       long: 5.3.2
 
   proxy-from-env@2.1.0: {}
@@ -8345,7 +8356,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.24.6: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -8517,6 +8528,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 

--- a/solana/javascript/on-demand/src/accounts/queue.ts
+++ b/solana/javascript/on-demand/src/accounts/queue.ts
@@ -23,18 +23,27 @@ import {
   UnsupportedSolanaClusterError,
 } from '../utils/solanaCluster.js';
 
-import { Oracle } from './oracle.js';
+import { Oracle, type OracleAccountData } from './oracle.js';
 import type { SwitchboardPermission } from './permission.js';
 import { Permission } from './permission.js';
 import { State } from './state.js';
 
 import type { Program } from '@coral-xyz/anchor-31';
 import { BN, web3 } from '@coral-xyz/anchor-31';
-import type { IOracleFeed } from '@switchboard-xyz/common';
+import type {
+  IOracleFeed,
+  MergedHealthyOracleIndex,
+  OracleHealthData,
+  RandomnessOracleSelectionMetadata,
+  RandomnessOracleSelectorCandidate,
+} from '@switchboard-xyz/common';
 import {
   CrossbarClient,
   CrossbarNetwork,
   FeedHash,
+  fetchHealthyOracleSnapshots,
+  mergeHealthyOracleSnapshots,
+  selectRandomnessOracle as selectRandomnessOracleCandidate,
 } from '@switchboard-xyz/common';
 import axios from 'axios';
 import { Buffer } from 'buffer';
@@ -76,6 +85,69 @@ interface HealthResponse {
   system_time: number;
   restricted: boolean;
   api_key_service_url: string;
+}
+
+export interface SolanaRandomnessOracleCandidate
+  extends RandomnessOracleSelectorCandidate {
+  oracle: Oracle;
+}
+
+export interface SolanaRandomnessOracleSelection {
+  oracle: Oracle;
+  metadata: RandomnessOracleSelectionMetadata;
+}
+
+export interface SolanaRandomnessOracleInspection {
+  candidates: SolanaRandomnessOracleCandidate[];
+  liveHealth: MergedHealthyOracleIndex;
+  metadata: RandomnessOracleSelectionMetadata;
+  queueData: QueueAccountData;
+  selectedCandidate: SolanaRandomnessOracleCandidate;
+}
+
+interface BuildSolanaRandomnessOracleCandidateArgs {
+  data: OracleAccountData;
+  liveOracleHealth?: OracleHealthData;
+  oracle: Oracle;
+  queueData: QueueAccountData;
+  version?: string;
+}
+
+export function buildSolanaRandomnessOracleCandidate({
+  data,
+  liveOracleHealth,
+  oracle,
+  queueData,
+  version,
+}: BuildSolanaRandomnessOracleCandidateArgs): SolanaRandomnessOracleCandidate {
+  const nowUnix = Math.floor(Date.now() / 1000);
+  const liveOracleConfig = liveOracleHealth?.oracle_config;
+  const gatewayUrl = Buffer.from(data.gatewayUri)
+    .toString()
+    .replace(/\0+$/, '');
+
+  return {
+    oracle,
+    oracleId: oracle.pubkey.toBase58(),
+    gatewayUrl,
+    version: liveOracleConfig?.version ?? version ?? undefined,
+    isOnQueue: data.isOnQueue,
+    isVerified: data.enclave.verificationStatus === 4,
+    heartbeatFresh:
+      nowUnix - data.lastHeartbeat.toNumber() <=
+      queueData.nodeTimeout.toNumber(),
+    quoteFresh: data.enclave.validUntil.toNumber() > nowUnix,
+    liveHealthy: Boolean(liveOracleHealth),
+    restricted: liveOracleConfig?.restricted,
+    gatewayEnabled: liveOracleHealth ? gatewayUrl.length > 0 : undefined,
+    pullOracleEnabled:
+      liveOracleHealth && liveOracleConfig?.enable_pull_oracle === 1,
+    lastHeartbeatUnix: data.lastHeartbeat.toNumber(),
+    validUntilUnix: data.enclave.validUntil.toNumber(),
+    activeConnections: liveOracleHealth?.active_connections,
+    totalSubscriptions: liveOracleHealth?.total_subscriptions,
+    totalFeeds: liveOracleHealth?.total_feeds,
+  };
 }
 
 /**
@@ -338,6 +410,79 @@ export class Queue {
     const randomIndex = Math.floor(Math.random() * oracleKeys.length);
     const selectedOracleKey = oracleKeys[randomIndex];
     return new Oracle(this.program, selectedOracleKey);
+  }
+
+  /**
+   * Fetches the healthiest randomness oracle for this queue.
+   *
+   * This path prefers gateway-confirmed healthy oracles and only falls back to
+   * verified, non-stale queue members when live health data is unavailable.
+   */
+  async inspectRandomnessOracles(
+    crossbarClient: CrossbarClient = CrossbarClient.default()
+  ): Promise<SolanaRandomnessOracleInspection> {
+    const queueData = await this.loadData();
+    const oracleKeys = queueData.oracleKeys.slice(0, queueData.oracleKeysLen);
+
+    if (oracleKeys.length === 0) {
+      throw new Error('No oracles found on queue');
+    }
+
+    const oracleData = await Oracle.loadMany(this.program, oracleKeys);
+    const loadedOracleData = oracleData.map((data, index) => {
+      if (!data) {
+        throw new Error(
+          `Failed to load oracle data for queue member ${oracleKeys[index].toBase58()}`
+        );
+      }
+
+      return data;
+    });
+    const onChainGatewayUrls = loadedOracleData
+      .map(data => Buffer.from(data.gatewayUri).toString().replace(/\0+$/, ''))
+      .filter((gatewayUrl): gatewayUrl is string => gatewayUrl.length > 0);
+    const gatewayUrls = await this.fetchRandomnessGatewayUrls(
+      crossbarClient
+    ).catch(() => onChainGatewayUrls);
+    const liveHealth = mergeHealthyOracleSnapshots(
+      await fetchHealthyOracleSnapshots(gatewayUrls)
+    );
+
+    const candidates = oracleKeys.map((oracleKey, index) =>
+      buildSolanaRandomnessOracleCandidate({
+        oracle: new Oracle(this.program, oracleKey),
+        data: loadedOracleData[index],
+        liveOracleHealth: liveHealth.byPullOracle.get(oracleKey.toBase58()),
+        queueData,
+        version: liveHealth.majorityVersion ?? undefined,
+      })
+    );
+
+    const selection = selectRandomnessOracleCandidate(candidates);
+    return {
+      candidates,
+      liveHealth,
+      metadata: selection.metadata,
+      queueData,
+      selectedCandidate: selection.candidate,
+    };
+  }
+
+  async selectRandomnessOracle(
+    crossbarClient: CrossbarClient = CrossbarClient.default()
+  ): Promise<SolanaRandomnessOracleSelection> {
+    const selection = await this.inspectRandomnessOracles(crossbarClient);
+    return {
+      oracle: selection.selectedCandidate.oracle,
+      metadata: selection.metadata,
+    };
+  }
+
+  async fetchFreshOracle(
+    crossbarClient: CrossbarClient = CrossbarClient.default()
+  ): Promise<web3.PublicKey> {
+    const selection = await this.inspectRandomnessOracles(crossbarClient);
+    return selection.selectedCandidate.oracle.pubkey;
   }
 
   /**
@@ -619,6 +764,16 @@ export class Queue {
       ));
     this.network = getCrossbarNetworkForCluster(cluster);
     return this.network;
+  }
+
+  private async fetchRandomnessGatewayUrls(
+    crossbarClient: CrossbarClient
+  ): Promise<string[]> {
+    const network = await this.resolveCrossbarNetwork();
+    crossbarClient.setNetwork(network);
+    return crossbarClient.fetchGateways(
+      network === CrossbarNetwork.SolanaMainnet ? 'mainnet' : 'devnet'
+    );
   }
 
   /**

--- a/solana/javascript/on-demand/src/evm/index.ts
+++ b/solana/javascript/on-demand/src/evm/index.ts
@@ -10,7 +10,25 @@ import {
   createV0AttestationHexString,
 } from './message.js';
 
-import { CrossbarClient, IOracleJob, OracleJob } from '@switchboard-xyz/common';
+import { keccak_256 } from '@noble/hashes/sha3';
+import {
+  createFallbackOracleInfo,
+  CrossbarClient,
+  evaluateRandomnessOracleCandidate,
+  fetchHealthyOracleSnapshots,
+  getActiveRandomnessEvmDeployment,
+  getCrossbarOracleNetworkForEvmChainId,
+  IOracleJob,
+  isRandomnessOracleCandidateEligible,
+  type MergedHealthyOracleIndex,
+  mergeHealthyOracleSnapshots,
+  type OracleHealthData,
+  type OracleInfo,
+  OracleJob,
+  type RandomnessOracleSelectionMetadata,
+  type RandomnessOracleSelectorCandidate,
+  selectRandomnessOracle as selectRandomnessOracleCandidate,
+} from '@switchboard-xyz/common';
 import axios from 'axios';
 import { Buffer } from 'buffer';
 
@@ -121,6 +139,34 @@ export interface FetchRandomnessArgs {
   minStalenessSeconds?: number;
 }
 
+export interface SelectEvmRandomnessOracleArgs {
+  chainId: number;
+  crossbarUrl?: string;
+}
+
+export interface EvmRandomnessOracleCandidate
+  extends RandomnessOracleSelectorCandidate {
+  authority: string;
+  pubkey: string;
+  secp256k1Key: string;
+  signingAddress: string;
+}
+
+export interface EvmRandomnessOracleSelection {
+  candidate: EvmRandomnessOracleCandidate;
+  deploymentId: string;
+  metadata: RandomnessOracleSelectionMetadata;
+  network: 'mainnet' | 'devnet';
+  oracle: string;
+}
+
+export interface EvmRandomnessOracleInspection
+  extends EvmRandomnessOracleSelection {
+  candidates: EvmRandomnessOracleCandidate[];
+  liveHealth: MergedHealthyOracleIndex;
+  oracles: OracleInfo[];
+}
+
 /**
  * Get an oracle job from object definition
  * @param params the job parameters
@@ -132,6 +178,257 @@ export function createJob(params: IOracleJob): OracleJob {
 
 function getCrossbarUrl(crossbarUrl?: string): string {
   return crossbarUrl ?? CrossbarClient.default().crossbarUrl;
+}
+
+function normalizeUnixTimestamp(value?: number): number | undefined {
+  const numericValue = value ?? Number.NaN;
+  if (!Number.isFinite(numericValue)) {
+    return undefined;
+  }
+
+  return numericValue > 1_000_000_000_000
+    ? Math.floor(numericValue / 1000)
+    : numericValue;
+}
+
+function resolveGatewayUrl(
+  oracle: OracleInfo,
+  healthData?: OracleHealthData
+): string | undefined {
+  return oracle.gatewayUrl ?? healthData?.oracle_config?.gateway_ingress;
+}
+
+function trimHexPrefix(value: string): string {
+  return value.replace(/^0x/i, '');
+}
+
+function normalizeExplicitSigningAddress(
+  signingAddress?: string | null
+): string | undefined {
+  const normalized = signingAddress?.trim().toLowerCase();
+  return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeUncompressedSecp256k1Key(
+  secp256k1Key?: string | null
+): string | undefined {
+  let key = trimHexPrefix(secp256k1Key?.trim() ?? '');
+  if (key.length === 130 && key.slice(0, 2).toLowerCase() === '04') {
+    key = key.slice(2);
+  }
+
+  if (key.length !== 128 || !/^[0-9a-fA-F]+$/.test(key)) {
+    return undefined;
+  }
+
+  return key;
+}
+
+export function deriveEvmAddressFromSecp256k1Key(
+  secp256k1Key?: string | null
+): string | undefined {
+  const normalizedKey = normalizeUncompressedSecp256k1Key(secp256k1Key);
+  if (!normalizedKey) {
+    return undefined;
+  }
+
+  const hash = keccak_256(Buffer.from(normalizedKey, 'hex'));
+  return `0x${Buffer.from(hash.slice(-20)).toString('hex')}`;
+}
+
+export function resolveEvmOracleSigningAddress(
+  oracle: Pick<OracleInfo, 'signingAddress' | 'secp256k1Key'>
+): string | undefined {
+  return (
+    normalizeExplicitSigningAddress(oracle.signingAddress) ??
+    deriveEvmAddressFromSecp256k1Key(oracle.secp256k1Key)
+  );
+}
+
+export function buildEvmRandomnessOracleCandidate(
+  oracle: OracleInfo,
+  healthData?: OracleHealthData
+): EvmRandomnessOracleCandidate {
+  const lastHeartbeatUnix = normalizeUnixTimestamp(
+    healthData?.oracle_config?.system_time
+  );
+  const fallbackCandidate = createFallbackOracleInfo(oracle);
+  const signingAddress = resolveEvmOracleSigningAddress(oracle);
+  const gatewayUrl = resolveGatewayUrl(oracle, healthData);
+
+  return {
+    ...fallbackCandidate,
+    oracleId: signingAddress ?? fallbackCandidate.oracleId,
+    authority: oracle.authority,
+    pubkey: oracle.pubkey,
+    secp256k1Key: oracle.secp256k1Key,
+    signingAddress: signingAddress ?? '',
+    gatewayUrl,
+    version:
+      healthData?.oracle_config?.version ??
+      oracle.version ??
+      fallbackCandidate.version,
+    liveHealthy: Boolean(healthData),
+    heartbeatFresh: healthData ? true : fallbackCandidate.heartbeatFresh,
+    // Crossbar expirationTime tracks discovery freshness, not enclave quote
+    // validity, so EVM randomness keeps quote freshness independent of it.
+    quoteFresh: fallbackCandidate.quoteFresh,
+    restricted:
+      healthData?.oracle_config?.restricted ??
+      oracle.restricted ??
+      fallbackCandidate.restricted,
+    gatewayEnabled: healthData
+      ? Boolean(gatewayUrl)
+      : fallbackCandidate.gatewayEnabled,
+    pullOracleEnabled: healthData
+      ? healthData.oracle_config?.enable_pull_oracle === 1
+      : fallbackCandidate.pullOracleEnabled,
+    lastHeartbeatUnix,
+    validUntilUnix: undefined,
+    activeConnections: healthData?.active_connections,
+    totalSubscriptions: healthData?.total_subscriptions,
+    totalFeeds: healthData?.total_feeds,
+  };
+}
+
+export function selectStrictEvmRandomnessOracleCandidate(
+  candidates: EvmRandomnessOracleCandidate[]
+): {
+  candidate: EvmRandomnessOracleCandidate;
+  metadata: RandomnessOracleSelectionMetadata;
+} {
+  if (candidates.length === 0) {
+    throw new Error('No randomness oracle candidates were provided');
+  }
+
+  const evaluations = candidates.map(evaluateRandomnessOracleCandidate);
+  const liveEligibleCandidates = candidates.filter(
+    candidate =>
+      candidate.liveHealthy && isRandomnessOracleCandidateEligible(candidate)
+  );
+
+  if (liveEligibleCandidates.length === 0) {
+    throw new Error('No eligible randomness oracle candidates were found');
+  }
+
+  const liveSelection = selectRandomnessOracleCandidate(liveEligibleCandidates);
+  const majorityVersion = liveSelection.metadata.majorityVersion;
+
+  for (const evaluation of evaluations) {
+    if (evaluation.oracleId === liveSelection.candidate.oracleId) {
+      evaluation.tier = 'live';
+    } else if (
+      majorityVersion !== null &&
+      evaluation.version !== null &&
+      evaluation.version !== majorityVersion
+    ) {
+      evaluation.rejectionReasons = [
+        ...evaluation.rejectionReasons,
+        'version-mismatch',
+      ];
+    }
+  }
+
+  return {
+    candidate: liveSelection.candidate,
+    metadata: {
+      tier: 'live',
+      majorityVersion,
+      liveHealthyCandidateCount: liveEligibleCandidates.length,
+      fallbackCandidateCount: 0,
+      evaluations,
+    },
+  };
+}
+
+/**
+ * Select a healthy EVM randomness oracle from the active deployment inventory.
+ *
+ * This requires live gateway health and does not fall back to inventory-only
+ * candidates.
+ */
+export async function inspectRandomnessOracleSelection({
+  chainId,
+  crossbarUrl,
+}: SelectEvmRandomnessOracleArgs): Promise<EvmRandomnessOracleInspection> {
+  const deployment = getActiveRandomnessEvmDeployment(chainId);
+  if (!deployment) {
+    throw new Error(
+      `Unsupported active randomness EVM deployment for chainId ${chainId}`
+    );
+  }
+
+  const network = getCrossbarOracleNetworkForEvmChainId(chainId);
+  const crossbar = new CrossbarClient(getCrossbarUrl(crossbarUrl));
+  const oracles = (await crossbar.fetchOracles(network)) as OracleInfo[];
+
+  if (oracles.length === 0) {
+    throw new Error(
+      `No Crossbar oracle inventory found for ${deployment.id} (${network})`
+    );
+  }
+
+  const gatewayUrls = await crossbar
+    .fetchGateways(network)
+    .catch(() =>
+      oracles
+        .map(oracle => oracle.gatewayUrl)
+        .filter((gatewayUrl): gatewayUrl is string => Boolean(gatewayUrl))
+    );
+  const healthySnapshots = await fetchHealthyOracleSnapshots(gatewayUrls);
+  const mergedSnapshots = mergeHealthyOracleSnapshots(healthySnapshots);
+  const candidates = oracles
+    .map(oracle =>
+      buildEvmRandomnessOracleCandidate(
+        oracle,
+        mergedSnapshots.bySecp256k1Key.get(oracle.secp256k1Key)
+      )
+    )
+    .filter(candidate => candidate.signingAddress.length > 0);
+
+  if (candidates.length === 0) {
+    throw new Error(
+      `No EVM randomness oracles exposed a signing address for ${deployment.id}`
+    );
+  }
+
+  const { candidate, metadata } =
+    selectStrictEvmRandomnessOracleCandidate(candidates);
+
+  return {
+    candidate,
+    candidates,
+    deploymentId: deployment.id,
+    liveHealth: mergedSnapshots,
+    metadata,
+    network,
+    oracle: candidate.signingAddress,
+    oracles,
+  };
+}
+
+/**
+ * Select a healthy EVM randomness oracle from the active deployment inventory.
+ *
+ * This requires live gateway health and does not fall back to inventory-only
+ * candidates.
+ */
+export async function selectRandomnessOracle({
+  chainId,
+  crossbarUrl,
+}: SelectEvmRandomnessOracleArgs): Promise<EvmRandomnessOracleSelection> {
+  const inspection = await inspectRandomnessOracleSelection({
+    chainId,
+    crossbarUrl,
+  });
+
+  return {
+    candidate: inspection.candidate,
+    deploymentId: inspection.deploymentId,
+    metadata: inspection.metadata,
+    network: inspection.network,
+    oracle: inspection.oracle,
+  };
 }
 
 /**

--- a/solana/javascript/on-demand/test/evmRandomnessOracleSelection.smoke.ts
+++ b/solana/javascript/on-demand/test/evmRandomnessOracleSelection.smoke.ts
@@ -1,0 +1,165 @@
+import {
+  evaluateRandomnessOracleCandidate,
+  type OracleHealthData,
+  type OracleInfo,
+} from '@switchboard-xyz/common';
+import assert from 'node:assert/strict';
+
+import {
+  buildEvmRandomnessOracleCandidate,
+  deriveEvmAddressFromSecp256k1Key,
+  resolveEvmOracleSigningAddress,
+  selectStrictEvmRandomnessOracleCandidate,
+} from '../src/evm/index.ts';
+
+const GENERATOR_PUBLIC_KEY =
+  '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798' +
+  '483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8';
+const GENERATOR_ETH_ADDRESS = '0x7e5f4552091a69125d5dfcb7b8c2659029395bdf';
+
+function oracleInfo(overrides: Partial<OracleInfo> = {}): OracleInfo {
+  return {
+    pubkey: 'oracle-pubkey',
+    secp256k1Key: GENERATOR_PUBLIC_KEY,
+    authority: 'oracle-authority',
+    queue: 'oracle-queue',
+    mrEnclave: '0x00',
+    expirationTime: Math.floor(Date.now() / 1000) - 3600,
+    gatewayUrl: 'https://gateway.example.com',
+    restricted: false,
+    version: 'test',
+    ...overrides,
+  };
+}
+
+const oldCrossbarCandidate = buildEvmRandomnessOracleCandidate(
+  oracleInfo({ signingAddress: undefined })
+);
+assert.equal(oldCrossbarCandidate.signingAddress, GENERATOR_ETH_ADDRESS);
+assert.equal(oldCrossbarCandidate.oracleId, GENERATOR_ETH_ADDRESS);
+
+assert.equal(
+  deriveEvmAddressFromSecp256k1Key(`0x04${GENERATOR_PUBLIC_KEY}`),
+  GENERATOR_ETH_ADDRESS
+);
+
+const explicitSigningAddress = '0xABCDEF0000000000000000000000000000000000';
+const explicitCandidate = buildEvmRandomnessOracleCandidate(
+  oracleInfo({
+    secp256k1Key: 'not-a-public-key',
+    signingAddress: explicitSigningAddress,
+  })
+);
+assert.equal(
+  explicitCandidate.signingAddress,
+  explicitSigningAddress.toLowerCase()
+);
+assert.equal(explicitCandidate.oracleId, explicitSigningAddress.toLowerCase());
+
+const malformedWithoutExplicit = oracleInfo({
+  secp256k1Key: 'not-a-public-key',
+  signingAddress: undefined,
+});
+assert.equal(
+  resolveEvmOracleSigningAddress(malformedWithoutExplicit),
+  undefined
+);
+assert.equal(
+  buildEvmRandomnessOracleCandidate(malformedWithoutExplicit).signingAddress,
+  ''
+);
+
+const inventoryOnlyCandidate = buildEvmRandomnessOracleCandidate(
+  oracleInfo({
+    signingAddress: '0x1111111111111111111111111111111111111111',
+  })
+);
+const inventoryOnlyEvaluation = evaluateRandomnessOracleCandidate(
+  inventoryOnlyCandidate
+);
+assert.equal(inventoryOnlyCandidate.quoteFresh, true);
+assert.equal(inventoryOnlyCandidate.validUntilUnix, undefined);
+assert.equal(inventoryOnlyCandidate.liveHealthy, false);
+assert.equal(
+  inventoryOnlyEvaluation.rejectionReasons.includes('quote-expired'),
+  false
+);
+assert.equal(
+  inventoryOnlyEvaluation.rejectionReasons.includes('health-data-unavailable'),
+  true
+);
+
+assert.throws(
+  () => selectStrictEvmRandomnessOracleCandidate([inventoryOnlyCandidate]),
+  /No eligible randomness oracle candidates were found/
+);
+
+const liveHealth: OracleHealthData = {
+  oracle_url: 'https://oracle.example.com',
+  active_connections: 1,
+  unique_ips: 1,
+  total_subscriptions: 2,
+  active_monitors: 1,
+  total_symbols: 3,
+  total_feeds: 4,
+  oracle_config: {
+    pull_oracle: inventoryOnlyCandidate.pubkey,
+    secp256k1_pubkey: inventoryOnlyCandidate.secp256k1Key,
+    version: inventoryOnlyCandidate.version,
+    system_time: Math.floor(Date.now() / 1000),
+    enable_gateway: 0,
+    enable_pull_oracle: 1,
+    gateway_ingress: inventoryOnlyCandidate.gatewayUrl,
+    restricted: false,
+  },
+};
+
+const liveCandidate = buildEvmRandomnessOracleCandidate(
+  oracleInfo({
+    signingAddress: '0x1111111111111111111111111111111111111111',
+  }),
+  liveHealth
+);
+assert.equal(liveCandidate.quoteFresh, true);
+assert.equal(liveCandidate.validUntilUnix, undefined);
+assert.equal(liveCandidate.liveHealthy, true);
+assert.equal(liveCandidate.gatewayEnabled, true);
+assert.equal(liveCandidate.pullOracleEnabled, true);
+
+const selection = selectStrictEvmRandomnessOracleCandidate([liveCandidate]);
+assert.equal(selection.candidate.oracleId, liveCandidate.oracleId);
+assert.equal(selection.metadata.tier, 'live');
+assert.equal(selection.metadata.liveHealthyCandidateCount, 1);
+assert.equal(selection.metadata.fallbackCandidateCount, 0);
+assert.deepEqual(selection.metadata.evaluations[0]?.rejectionReasons, []);
+
+const disabledPullOracleCandidate = buildEvmRandomnessOracleCandidate(
+  oracleInfo({
+    signingAddress: '0x2222222222222222222222222222222222222222',
+  }),
+  {
+    ...liveHealth,
+    oracle_config: {
+      ...liveHealth.oracle_config,
+      enable_gateway: 1,
+      enable_pull_oracle: 0,
+    },
+  }
+);
+const disabledPullOracleEvaluation = evaluateRandomnessOracleCandidate(
+  disabledPullOracleCandidate
+);
+assert.equal(disabledPullOracleCandidate.gatewayEnabled, true);
+assert.equal(disabledPullOracleCandidate.pullOracleEnabled, false);
+assert.equal(
+  disabledPullOracleEvaluation.rejectionReasons.includes(
+    'pull-oracle-disabled'
+  ),
+  true
+);
+assert.throws(
+  () => selectStrictEvmRandomnessOracleCandidate([disabledPullOracleCandidate]),
+  /No eligible randomness oracle candidates were found/
+);
+
+console.log('evm randomness oracle selection smoke test passed');

--- a/solana/javascript/on-demand/test/solanaRandomnessOracleSelection.smoke.ts
+++ b/solana/javascript/on-demand/test/solanaRandomnessOracleSelection.smoke.ts
@@ -1,0 +1,88 @@
+import {
+  evaluateRandomnessOracleCandidate,
+  isRandomnessOracleCandidateEligible,
+  type OracleHealthData,
+} from '@switchboard-xyz/common';
+import assert from 'node:assert/strict';
+
+import { buildSolanaRandomnessOracleCandidate } from '../src/accounts/queue.ts';
+
+import { BN, web3 } from '@coral-xyz/anchor-31';
+
+const nowUnix = Math.floor(Date.now() / 1000);
+const oraclePubkey = new web3.PublicKey(new Uint8Array(32).fill(1));
+const gatewayUrl = 'https://gateway.example.com/mainnet';
+
+function createHealth(enablePullOracle: number): OracleHealthData {
+  return {
+    oracle_url: gatewayUrl,
+    active_connections: 1,
+    unique_ips: 1,
+    total_subscriptions: 2,
+    active_monitors: 1,
+    total_symbols: 3,
+    total_feeds: 4,
+    oracle_config: {
+      pull_oracle: oraclePubkey.toBase58(),
+      secp256k1_pubkey: 'secp256k1-pubkey',
+      version: 'test',
+      system_time: nowUnix,
+      enable_gateway: 0,
+      enable_pull_oracle: enablePullOracle,
+      gateway_ingress: gatewayUrl,
+      restricted: false,
+    },
+  };
+}
+
+function buildCandidate(enablePullOracle: number) {
+  return buildSolanaRandomnessOracleCandidate({
+    data: {
+      gatewayUri: Buffer.from(gatewayUrl),
+      isOnQueue: true,
+      enclave: {
+        verificationStatus: 4,
+        validUntil: new BN(nowUnix + 3600),
+      },
+      lastHeartbeat: new BN(nowUnix),
+    } as any,
+    liveOracleHealth: createHealth(enablePullOracle),
+    oracle: { pubkey: oraclePubkey } as any,
+    queueData: { nodeTimeout: new BN(300) } as any,
+  });
+}
+
+const enabledPullOracleCandidate = buildCandidate(1);
+const enabledPullOracleEvaluation = evaluateRandomnessOracleCandidate(
+  enabledPullOracleCandidate
+);
+
+assert.equal(enabledPullOracleCandidate.liveHealthy, true);
+assert.equal(enabledPullOracleCandidate.gatewayEnabled, true);
+assert.equal(enabledPullOracleCandidate.pullOracleEnabled, true);
+assert.equal(
+  isRandomnessOracleCandidateEligible(enabledPullOracleCandidate),
+  true
+);
+assert.deepEqual(enabledPullOracleEvaluation.rejectionReasons, []);
+
+const disabledPullOracleCandidate = buildCandidate(0);
+const disabledPullOracleEvaluation = evaluateRandomnessOracleCandidate(
+  disabledPullOracleCandidate
+);
+
+assert.equal(disabledPullOracleCandidate.liveHealthy, true);
+assert.equal(disabledPullOracleCandidate.gatewayEnabled, true);
+assert.equal(disabledPullOracleCandidate.pullOracleEnabled, false);
+assert.equal(
+  isRandomnessOracleCandidateEligible(disabledPullOracleCandidate),
+  false
+);
+assert.equal(
+  disabledPullOracleEvaluation.rejectionReasons.includes(
+    'pull-oracle-disabled'
+  ),
+  true
+);
+
+console.log('solana randomness oracle selection smoke test passed');

--- a/solana/rust/switchboard-on-demand-client/README.md
+++ b/solana/rust/switchboard-on-demand-client/README.md
@@ -10,7 +10,7 @@ A middleman service to fetch oracle jobs from IPFS and to return feed price simu
 Before publishing this crate to crates.io, commit the release changes to `main` or create a release tag that points at the release commit, then run:
 
 ```bash
-rust/switchboard-on-demand-client/scripts/verify-crate-release.sh
+solana/rust/switchboard-on-demand-client/scripts/verify-crate-release.sh
 ```
 
 The script refuses to package from a dirty tree, refuses non-`main` branches unless the commit is tagged, and verifies the generated crate's `.cargo_vcs_info.json` has `dirty = false` and points at the release commit. Do not publish if this check fails.

--- a/solana/rust/switchboard-on-demand-client/scripts/verify-crate-release.sh
+++ b/solana/rust/switchboard-on-demand-client/scripts/verify-crate-release.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
-crate_rel="rust/switchboard-on-demand-client"
+crate_rel="solana/rust/switchboard-on-demand-client"
 crate_dir="$repo_root/$crate_rel"
 manifest="$crate_dir/Cargo.toml"
 
@@ -54,7 +54,7 @@ if (!info.git) {
   throw new Error('missing git metadata in .cargo_vcs_info.json');
 }
 
-if (info.git.dirty !== false) {
+if (info.git.dirty === true) {
   throw new Error('crate package was built from a dirty git state');
 }
 

--- a/solana/rust/switchboard-on-demand-client/src/lib.rs
+++ b/solana/rust/switchboard-on-demand-client/src/lib.rs
@@ -126,7 +126,7 @@ use solana_sdk::pubkey;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```rust,no_run
 /// use switchboard_on_demand_client::is_devnet;
 ///
 /// if is_devnet() {
@@ -157,7 +157,7 @@ pub const ON_DEMAND_DEVNET_PID: Pubkey = pubkey!("Aio4gaXjXzJNVLtzwtNVmSqGKpANtX
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```rust,no_run
 /// use switchboard_on_demand_client::get_switchboard_on_demand_program_id;
 ///
 /// let program_id = get_switchboard_on_demand_program_id();
@@ -225,20 +225,14 @@ pub const REWARD_POOL_VAULT_SEED: &[u8] = b"RewardPool";
 /// use solana_sdk::{
 ///     instruction::Instruction,
 ///     signature::{Keypair, Signer},
-///     system_instruction,
 ///     hash::Hash,
 /// };
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let payer = Keypair::new();
-/// let recipient = Keypair::new();
 /// let recent_blockhash = Hash::default(); // In practice, fetch from RPC
 ///
-/// let instruction = system_instruction::transfer(
-///     &payer.pubkey(),
-///     &recipient.pubkey(),
-///     1_000_000, // lamports
-/// );
+/// let instruction = Instruction::new_with_bytes(payer.pubkey(), &[], vec![]);
 ///
 /// let transaction = ix_to_tx(&[instruction], &[&payer], recent_blockhash)?;
 /// # Ok(())

--- a/solana/rust/switchboard-on-demand/Cargo.lock
+++ b/solana/rust/switchboard-on-demand/Cargo.lock
@@ -9059,7 +9059,7 @@ dependencies = [
 
 [[package]]
 name = "switchboard-on-demand"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anchor-lang",
  "anyhow",
@@ -9089,6 +9089,7 @@ dependencies = [
  "solana-account-decoder 3.0.10",
  "solana-client 2.3.12",
  "solana-client 3.0.10",
+ "solana-message 3.0.1",
  "solana-program 2.3.0",
  "solana-program 3.0.0",
  "solana-sdk 2.3.1",

--- a/solana/rust/switchboard-on-demand/Cargo.lock
+++ b/solana/rust/switchboard-on-demand/Cargo.lock
@@ -3284,9 +3284,16 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinocchio"
-version = "0.9.2"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b971851087bc3699b001954ad02389d50c41405ece3548cbcafc88b3e20017a"
+checksum = "a6cababcb62a2e739c7078ae16eda02789a6e3edd21bbdded864e85c38a7914d"
+dependencies = [
+ "solana-account-view",
+ "solana-address 2.6.1",
+ "solana-define-syscall 5.1.0",
+ "solana-instruction-view",
+ "solana-program-error 3.0.0",
+]
 
 [[package]]
 name = "pkcs8"
@@ -4387,6 +4394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
+
+[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4668,6 +4681,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-account-view"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc141b940560430425ebaadb7645496c45f6a10fad9911d719bd03eab7f4d422"
+dependencies = [
+ "solana-address 2.6.1",
+ "solana-program-error 3.0.0",
+]
+
+[[package]]
 name = "solana-address"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4686,6 +4709,18 @@ dependencies = [
  "solana-define-syscall 3.0.0",
  "solana-program-error 3.0.0",
  "solana-sanitize 3.0.1",
+ "solana-sha256-hasher 3.0.0",
+]
+
+[[package]]
+name = "solana-address"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c93e262f671bf402e1040e4a7e40b05d81da5956c7681948c975a0997517bb"
+dependencies = [
+ "sha2-const-stable",
+ "solana-define-syscall 5.1.0",
+ "solana-program-error 3.0.0",
  "solana-sha256-hasher 3.0.0",
 ]
 
@@ -5199,6 +5234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
 
 [[package]]
+name = "solana-define-syscall"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+
+[[package]]
 name = "solana-derivation-path"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5619,6 +5660,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-instruction-view"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab7a27d0c4214b9f7389c3dd00b68c93093a67f1dcc5b7893aebe299bbcbb47"
+dependencies = [
+ "solana-account-view",
+ "solana-address 2.6.1",
+ "solana-define-syscall 5.1.0",
+ "solana-program-error 3.0.0",
+]
+
+[[package]]
 name = "solana-instructions-sysvar"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5856,7 +5909,7 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_derive",
- "solana-address",
+ "solana-address 1.0.0",
  "solana-hash 3.0.0",
  "solana-instruction 3.0.0",
  "solana-sanitize 3.0.1",
@@ -6453,7 +6506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
 dependencies = [
  "rand 0.8.5",
- "solana-address",
+ "solana-address 1.0.0",
 ]
 
 [[package]]
@@ -7884,7 +7937,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-address",
+ "solana-address 1.0.0",
  "solana-hash 3.0.0",
  "solana-instruction 3.0.0",
  "solana-instruction-error",
@@ -9059,7 +9112,7 @@ dependencies = [
 
 [[package]]
 name = "switchboard-on-demand"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "anchor-lang",
  "anyhow",

--- a/solana/rust/switchboard-on-demand/Cargo.toml
+++ b/solana/rust/switchboard-on-demand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "switchboard-on-demand"
-version = "0.12.2"
+version = "0.13.0"
 # docs.rs autobuild has difficulty with ahash dep. Host yuorself at https://tiiny.host/
 documentation = "https://docs.rs/switchboard-on-demand/latest/switchboard_on_demand"
 edition = "2021"
@@ -94,7 +94,7 @@ faster-hex = "0.10.0"
 futures = { version = "0.3.31", optional = true }
 hex = { version = "0.4", optional = true }
 libsecp256k1 = { version = "0.7.2", default-features = false, features = ["static-context"] }
-pinocchio = { version = "0.9.2", features = ["std"], optional = true }
+pinocchio = { version = "0.11.1", optional = true }
 prost = { version = "0.13.1", optional = true }
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false, optional = true }
 rust_decimal = "^1"

--- a/solana/rust/switchboard-on-demand/Cargo.toml
+++ b/solana/rust/switchboard-on-demand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "switchboard-on-demand"
-version = "0.12.1"
+version = "0.12.2"
 # docs.rs autobuild has difficulty with ahash dep. Host yuorself at https://tiiny.host/
 documentation = "https://docs.rs/switchboard-on-demand/latest/switchboard_on_demand"
 edition = "2021"
@@ -11,6 +11,7 @@ keywords = ["switchboard", "oracle", "solana"]
 homepage = "https://switchboard.xyz"
 repository = "https://github.com/switchboard-xyz/solana-sdk/tree/main"
 license = "MIT"
+exclude = [".env"]
 
 [lib]
 crate-type = ["cdylib", "lib"]
@@ -45,7 +46,7 @@ client-v2 = ["client"]
 
 ## Client feature using Solana v3 crates.
 ## Uses v2 compat modules for types that haven't been published for v3 yet.
-client-v3 = ["tokio", "futures", "reqwest", "prost", "dashmap", "tokio-stream", "bs58", "hex", "base64", "serde_json", "switchboard-utils", "solana-v3", "dep:solana-account-decoder-v3", "dep:solana-client-v3", "dep:solana-sdk-v3", "dep:solana-sdk-v2"]
+client-v3 = ["tokio", "futures", "reqwest", "prost", "dashmap", "tokio-stream", "bs58", "hex", "base64", "serde_json", "switchboard-utils", "solana-v3", "dep:solana-account-decoder-v3", "dep:solana-client-v3", "dep:solana-message-v3", "dep:solana-sdk-v3", "dep:solana-sdk-v2", "dep:chrono", "dep:futures-util", "dep:tokio-tungstenite", "dep:url"]
 
 ## Configures the crate for Solana devnet deployment.
 devnet = []
@@ -66,7 +67,7 @@ pinocchio = ["dep:pinocchio"]
 test_only_ignore_singers = []
 
 ## Uses Solana SDK version 2.x (>= 2).
-solana-v2 = ["dep:solana-program-v2"]
+solana-v2 = []
 
 ## Uses Solana SDK version 3.x (>= 3).
 solana-v3 = ["dep:solana-program-v3"]
@@ -83,7 +84,7 @@ arrayref = "0.3.9"
 base64 = { version = "0.22", optional = true }
 base64ct = "<1.8"
 bincode = { version = "^1" }
-borsh = { version = "1.5.7" }
+borsh = { version = "1.5.7", features = ["derive"] }
 bs58 = { version = "0.4", features = ["alloc"], optional = true }
 bytemuck = { version = "^1", features = ["derive"] }
 chrono = { version = "0.4", optional = true }
@@ -104,7 +105,8 @@ solana-account-decoder-v2 = { package = "solana-account-decoder", version = ">=2
 solana-account-decoder-v3 = { package = "solana-account-decoder", version = ">=3", optional = true }
 solana-client-v2 = { package = "solana-client", version = ">=2,<3", optional = true }
 solana-client-v3 = { package = "solana-client", version = ">=3", optional = true }
-solana-program-v2 = { package = "solana-program", version = ">=2,<3", default-features = false, features = ["borsh"], optional = true }
+solana-message-v3 = { package = "solana-message", version = ">=3,<4", optional = true }
+solana-program-v2 = { package = "solana-program", version = ">=2,<3", default-features = false, features = ["borsh"] }
 solana-program-v3 = { package = "solana-program", version = ">=3", default-features = false, features = ["borsh"], optional = true }
 solana-sdk-v2 = { package = "solana-sdk", version = ">=2,<3", optional = true }
 solana-sdk-v3 = { package = "solana-sdk", version = ">=3", optional = true }

--- a/solana/rust/switchboard-on-demand/src/account_info_compat.rs
+++ b/solana/rust/switchboard-on-demand/src/account_info_compat.rs
@@ -1,12 +1,16 @@
 //! Compatibility layer for different AccountInfo types
 //!
 //! This module provides compatibility between different AccountInfo implementations,
-//! using pinocchio AccountInfo internally when the pinocchio feature is enabled,
+//! using pinocchio AccountView internally when the pinocchio feature is enabled,
 //! otherwise falling back to anchor/solana-program AccountInfo types.
 
-// Use pinocchio AccountInfo when the feature is enabled for better performance
+// Use pinocchio AccountView when the feature is enabled for better performance.
 #[cfg(feature = "pinocchio")]
-pub type AccountInfo = pinocchio::account_info::AccountInfo;
+pub type AccountView = pinocchio::AccountView;
+
+// Backwards-compatible alias for existing callers that import AccountInfo from this crate.
+#[cfg(feature = "pinocchio")]
+pub type AccountInfo = AccountView;
 
 // Otherwise use the appropriate AccountInfo type based on anchor feature
 #[cfg(all(not(feature = "pinocchio"), feature = "anchor"))]
@@ -21,6 +25,11 @@ pub trait AsAccountInfo<'a> {
     fn as_account_info(&self) -> &AccountInfo;
 }
 
+#[cfg(feature = "pinocchio")]
+pub trait AsAccountInfoMut<'a>: AsAccountInfo<'a> {
+    fn as_account_info_mut(&mut self) -> &mut AccountInfo;
+}
+
 #[cfg(not(feature = "pinocchio"))]
 pub trait AsAccountInfo<'a> {
     fn as_account_info(&self) -> &AccountInfo<'a>;
@@ -31,6 +40,14 @@ pub trait AsAccountInfo<'a> {
 impl<'a> AsAccountInfo<'a> for AccountInfo {
     #[inline(always)]
     fn as_account_info(&self) -> &AccountInfo {
+        self
+    }
+}
+
+#[cfg(feature = "pinocchio")]
+impl<'a> AsAccountInfoMut<'a> for AccountInfo {
+    #[inline(always)]
+    fn as_account_info_mut(&mut self) -> &mut AccountInfo {
         self
     }
 }
@@ -52,6 +69,22 @@ impl<'a> AsAccountInfo<'a> for &AccountInfo {
     }
 }
 
+#[cfg(feature = "pinocchio")]
+impl<'a> AsAccountInfo<'a> for &mut AccountInfo {
+    #[inline(always)]
+    fn as_account_info(&self) -> &AccountInfo {
+        self
+    }
+}
+
+#[cfg(feature = "pinocchio")]
+impl<'a> AsAccountInfoMut<'a> for &mut AccountInfo {
+    #[inline(always)]
+    fn as_account_info_mut(&mut self) -> &mut AccountInfo {
+        self
+    }
+}
+
 #[cfg(not(feature = "pinocchio"))]
 impl<'a> AsAccountInfo<'a> for &AccountInfo<'a> {
     #[inline(always)]
@@ -65,7 +98,7 @@ impl<'a> AsAccountInfo<'a> for &AccountInfo<'a> {
 #[macro_export]
 macro_rules! get_account_key {
     ($account:expr) => {
-        $account.key()
+        $account.address()
     };
 }
 
@@ -81,7 +114,7 @@ macro_rules! get_account_key {
 #[macro_export]
 macro_rules! borrow_account_data {
     ($account:expr) => {
-        $account.borrow_data_unchecked()
+        unsafe { $account.borrow_unchecked() }
     };
 }
 
@@ -97,7 +130,7 @@ macro_rules! borrow_account_data {
 #[macro_export]
 macro_rules! borrow_mut_account_data {
     ($account:expr) => {
-        unsafe { $account.borrow_mut_data_unchecked() }
+        unsafe { $account.borrow_unchecked_mut() }
     };
 }
 

--- a/solana/rust/switchboard-on-demand/src/client/subscription.rs
+++ b/solana/rust/switchboard-on-demand/src/client/subscription.rs
@@ -152,10 +152,8 @@ cfg_client! {
         use crate::client::Queue;
         use std::sync::Arc;
 
-        #[cfg(feature = "solana-v2")]
         use crate::solana_compat::solana_client::nonblocking::rpc_client::RpcClient;
-        #[cfg(feature = "solana-v2")]
-        use crate::solana_sdk::signature::Keypair;
+        use crate::solana_compat::solana_sdk::signer::keypair::Keypair;
         use crate::Instruction;
 
     /// Parameters for creating a new subscription

--- a/solana/rust/switchboard-on-demand/src/client/transaction_builder.rs
+++ b/solana/rust/switchboard-on-demand/src/client/transaction_builder.rs
@@ -580,8 +580,8 @@ impl TransactionBuilder {
                 data: ix.data.clone(),
             }
         }).collect();
-        let converted_lookup_accounts: Vec<crate::solana_compat::AddressLookupTableAccount> = address_lookup_accounts.iter().map(|lut| {
-            crate::solana_compat::AddressLookupTableAccount {
+        let converted_lookup_accounts: Vec<crate::solana_compat::MessageAddressLookupTableAccount> = address_lookup_accounts.iter().map(|lut| {
+            crate::solana_compat::MessageAddressLookupTableAccount {
                 key: lut.key.to_bytes().into(),
                 addresses: lut.addresses.iter().map(|addr| addr.to_bytes().into()).collect(),
             }

--- a/solana/rust/switchboard-on-demand/src/client/utils.rs
+++ b/solana/rust/switchboard-on-demand/src/client/utils.rs
@@ -67,8 +67,8 @@ pub async fn ix_to_tx_v0(
     final_ixs.extend_from_slice(ixs);
 
     // Convert AddressLookupTableAccount types
-    let converted_luts: Vec<crate::solana_compat::AddressLookupTableAccount> = luts.iter().map(|lut| {
-        crate::solana_compat::AddressLookupTableAccount {
+    let converted_luts: Vec<crate::solana_compat::MessageAddressLookupTableAccount> = luts.iter().map(|lut| {
+        crate::solana_compat::MessageAddressLookupTableAccount {
             key: lut.key.to_bytes().into(),
             addresses: lut.addresses.iter().map(|addr| addr.to_bytes().into()).collect(),
         }
@@ -125,8 +125,8 @@ async fn estimate_compute_units(rpc_client: &RpcClient, ixs: &[Instruction], lut
     ixs.insert(0, compute_limit_ix_converted);
 
     // Convert AddressLookupTableAccount types for this function too
-    let converted_luts: Vec<crate::solana_compat::AddressLookupTableAccount> = luts.iter().map(|lut| {
-        crate::solana_compat::AddressLookupTableAccount {
+    let converted_luts: Vec<crate::solana_compat::MessageAddressLookupTableAccount> = luts.iter().map(|lut| {
+        crate::solana_compat::MessageAddressLookupTableAccount {
             key: lut.key.to_bytes().into(),
             addresses: lut.addresses.iter().map(|addr| addr.to_bytes().into()).collect(),
         }

--- a/solana/rust/switchboard-on-demand/src/lib.rs
+++ b/solana/rust/switchboard-on-demand/src/lib.rs
@@ -60,7 +60,9 @@ compile_error!("Cannot enable both 'solana-v2' and 'solana-v3' features. Choose 
 compile_error!("Cannot enable both 'client' (v2) and 'client-v3' features. Use 'client' for Solana v2 or 'client-v3' for Solana v3.");
 
 #[cfg(all(feature = "client-v2", feature = "client-v3"))]
-compile_error!("Cannot enable both 'client-v2' and 'client-v3' features. Choose one client version.");
+compile_error!(
+    "Cannot enable both 'client-v2' and 'client-v3' features. Choose one client version."
+);
 
 // When both solana-v2 and client features are enabled, provide type compatibility layers
 #[cfg(all(feature = "solana-v2", feature = "client"))]
@@ -161,6 +163,8 @@ pub use sysvar::*;
 /// AccountInfo compatibility layer
 mod account_info_compat;
 pub use account_info_compat::{AccountInfo, AsAccountInfo};
+#[cfg(feature = "pinocchio")]
+pub use account_info_compat::{AccountView, AsAccountInfoMut};
 
 cfg_client! {
     pub type RpcClient = crate::solana_compat::solana_client::nonblocking::rpc_client::RpcClient;

--- a/solana/rust/switchboard-on-demand/src/on_demand/accounts/oracle.rs
+++ b/solana/rust/switchboard-on-demand/src/on_demand/accounts/oracle.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "pinocchio")]
-type Ref<'a, T> = pinocchio::account_info::Ref<'a, T>;
+type Ref<'a, T> = pinocchio::account::Ref<'a, T>;
 
 #[cfg(not(feature = "pinocchio"))]
 use std::cell::Ref;
@@ -151,6 +151,12 @@ impl OracleAccountData {
     pub fn new<'info>(
         quote_account_info: &'info AccountInfo,
     ) -> Result<Ref<'info, OracleAccountData>, OnDemandError> {
+        #[cfg(feature = "pinocchio")]
+        let data = quote_account_info
+            .try_borrow()
+            .map_err(|_| OnDemandError::AccountBorrowError)?;
+
+        #[cfg(not(feature = "pinocchio"))]
         let data = quote_account_info
             .try_borrow_data()
             .map_err(|_| OnDemandError::AccountBorrowError)?;

--- a/solana/rust/switchboard-on-demand/src/on_demand/accounts/queue.rs
+++ b/solana/rust/switchboard-on-demand/src/on_demand/accounts/queue.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "pinocchio")]
-type Ref<'a, T> = pinocchio::account_info::Ref<'a, T>;
+type Ref<'a, T> = pinocchio::account::Ref<'a, T>;
 
 #[cfg(not(feature = "pinocchio"))]
 use std::cell::Ref;
@@ -175,6 +175,12 @@ impl QueueAccountData {
     pub fn new<'info>(
         attestation_queue_account_info: &'info AccountInfo,
     ) -> Result<Ref<'info, QueueAccountData>, OnDemandError> {
+        #[cfg(feature = "pinocchio")]
+        let data = attestation_queue_account_info
+            .try_borrow()
+            .map_err(|_| OnDemandError::AccountBorrowError)?;
+
+        #[cfg(not(feature = "pinocchio"))]
         let data = attestation_queue_account_info
             .try_borrow_data()
             .map_err(|_| OnDemandError::AccountBorrowError)?;

--- a/solana/rust/switchboard-on-demand/src/on_demand/oracle_quote/quote.rs
+++ b/solana/rust/switchboard-on-demand/src/on_demand/oracle_quote/quote.rs
@@ -12,6 +12,8 @@ use crate::solana_compat::sol_memcpy_;
 // Use our AccountInfo type alias that conditionally uses pinocchio or anchor/solana-program
 use crate::AccountInfo;
 use crate::{borrow_mut_account_data, check_pubkey_eq, AsAccountInfo, Instructions, Pubkey};
+#[cfg(feature = "pinocchio")]
+use crate::AsAccountInfoMut;
 
 #[allow(unused)]
 const SLOTS_PER_EPOCH: u64 = 432_000;
@@ -409,7 +411,38 @@ impl<'a> OracleQuote<'a> {
     ///
     /// Panics if the oracle account buffer is too small or slot validation fails.
     #[inline(always)]
-    pub fn write(clock_slot: u64, source: &[u8], queue: impl AsRef<[u8]>, oracle_account: &AccountInfo) {
+    #[cfg(feature = "pinocchio")]
+    pub fn write(
+        clock_slot: u64,
+        source: &[u8],
+        queue: impl AsRef<[u8]>,
+        oracle_account: &mut AccountInfo,
+    ) {
+        let mut dst_ref = borrow_mut_account_data!(oracle_account);
+        let dst: &mut [u8] = &mut dst_ref;
+        assert!(dst.len() >= 55); // discriminator(8) + queue(32) + u16 + minimum data (13 bytes)
+        unsafe {
+            let dst_ptr = dst.as_mut_ptr();
+            *(dst_ptr as *mut u64) = QUOTE_DISCRIMINATOR_U64_LE;
+            // Copy queue at offset 8 using 4 u64 writes
+            let queue_ptr = queue.as_ref().as_ptr() as *const u64;
+            let dst_queue_ptr = dst_ptr.add(8) as *mut u64;
+            *dst_queue_ptr = *queue_ptr;
+            *dst_queue_ptr.add(1) = *queue_ptr.add(1);
+            *dst_queue_ptr.add(2) = *queue_ptr.add(2);
+            *dst_queue_ptr.add(3) = *queue_ptr.add(3);
+        }
+        Self::store_delimited(clock_slot, source, &mut dst[40..]);
+    }
+
+    #[inline(always)]
+    #[cfg(not(feature = "pinocchio"))]
+    pub fn write(
+        clock_slot: u64,
+        source: &[u8],
+        queue: impl AsRef<[u8]>,
+        oracle_account: &AccountInfo,
+    ) {
         let mut dst_ref = borrow_mut_account_data!(oracle_account);
         let dst: &mut [u8] = &mut dst_ref;
         assert!(dst.len() >= 55); // discriminator(8) + queue(32) + u16 + minimum data (13 bytes)
@@ -453,6 +486,31 @@ impl<'a> OracleQuote<'a> {
     /// # Panics
     /// Panics if the oracle account buffer is too small for the data.
     #[inline(always)]
+    #[cfg(feature = "pinocchio")]
+    pub fn write_unchecked(
+        source: &[u8],
+        queue: impl AsRef<[u8]>,
+        oracle_account: &mut AccountInfo,
+    ) {
+        let mut dst_ref = borrow_mut_account_data!(oracle_account);
+        let dst: &mut [u8] = &mut dst_ref;
+        assert!(dst.len() >= 55); // discriminator(8) + queue(32) + u16 + minimum data (13 bytes)
+        unsafe {
+            let dst_ptr = dst.as_mut_ptr();
+            *(dst_ptr as *mut u64) = QUOTE_DISCRIMINATOR_U64_LE;
+            // Copy queue at offset 8 using 4 u64 writes
+            let queue_ptr = queue.as_ref().as_ptr() as *const u64;
+            let dst_queue_ptr = dst_ptr.add(8) as *mut u64;
+            *dst_queue_ptr = *queue_ptr;
+            *dst_queue_ptr.add(1) = *queue_ptr.add(1);
+            *dst_queue_ptr.add(2) = *queue_ptr.add(2);
+            *dst_queue_ptr.add(3) = *queue_ptr.add(3);
+        }
+        Self::store_delimited_unchecked(source, &mut dst[40..]);
+    }
+
+    #[inline(always)]
+    #[cfg(not(feature = "pinocchio"))]
     pub fn write_unchecked(source: &[u8], queue: impl AsRef<[u8]>, oracle_account: &AccountInfo) {
         let mut dst_ref = borrow_mut_account_data!(oracle_account);
         let dst: &mut [u8] = &mut dst_ref;
@@ -477,8 +535,8 @@ impl<'a> OracleQuote<'a> {
     /// and writes it to the target oracle account with proper validation and discriminator.
     ///
     /// # Arguments
-    /// * `ix_sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<Instructions>`, direct `AccountInfo` reference, pinocchio AccountInfo)
-    /// * `oracle_account` - Any type that implements `AsAccountInfo` (e.g., `AccountLoader<SwitchboardQuote>`, direct `AccountInfo` reference, pinocchio AccountInfo)
+    /// * `ix_sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<Instructions>`, direct `AccountInfo` reference, pinocchio AccountView)
+    /// * `oracle_account` - Any writable account type (mutable `AccountView` for pinocchio, `AccountInfo` for non-pinocchio builds)
     /// * `clock_slot` - Current slot value
     /// * `instruction_index` - Index of the ED25519 instruction to extract (typically 0)
     ///
@@ -506,6 +564,27 @@ impl<'a> OracleQuote<'a> {
     /// # Panics
     /// Panics if instruction extraction fails, program ID validation fails, or slot validation fails.
     #[inline(always)]
+    #[cfg(feature = "pinocchio")]
+    pub fn write_from_ix<'b, I, O, Q>(
+        ix_sysvar: I,
+        mut oracle_account: O,
+        queue: Q,
+        curr_slot: u64,
+        instruction_index: usize,
+    ) where
+        I: AsAccountInfo<'b>,
+        O: AsAccountInfoMut<'b>,
+        Q: AsRef<[u8]>,
+    {
+        let ix_sysvar = ix_sysvar.as_account_info();
+        let oracle_account = oracle_account.as_account_info_mut();
+
+        let data = Instructions::extract_ix_data(ix_sysvar, instruction_index);
+        Self::write(curr_slot, data, queue, oracle_account);
+    }
+
+    #[inline(always)]
+    #[cfg(not(feature = "pinocchio"))]
     pub fn write_from_ix<'b, I, O, Q>(
         ix_sysvar: I,
         oracle_account: O,
@@ -549,8 +628,8 @@ impl<'a> OracleQuote<'a> {
     /// - You're testing with simulated data
     ///
     /// # Arguments
-    /// * `ix_sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<Instructions>`, direct `AccountInfo` reference, pinocchio AccountInfo)
-    /// * `oracle_account` - Any type that implements `AsAccountInfo` (e.g., `AccountLoader<SwitchboardQuote>`, direct `AccountInfo` reference, pinocchio AccountInfo)
+    /// * `ix_sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<Instructions>`, direct `AccountInfo` reference, pinocchio AccountView)
+    /// * `oracle_account` - Any writable account type (mutable `AccountView` for pinocchio, `AccountInfo` for non-pinocchio builds)
     /// * `instruction_index` - Index of the ED25519 instruction to extract (typically 0)
     ///
     /// # Example with Anchor
@@ -590,6 +669,27 @@ impl<'a> OracleQuote<'a> {
     /// [`write_from_ix`]: Self::write_from_ix
     #[inline(always)]
     #[allow(clippy::missing_safety_doc)] // Safety documentation is comprehensive above
+    #[cfg(feature = "pinocchio")]
+    pub fn write_from_ix_unchecked<'b, I, O, Q>(
+        ix_sysvar: I,
+        mut oracle_account: O,
+        queue: Q,
+        instruction_index: usize,
+    ) where
+        I: AsAccountInfo<'b>,
+        O: AsAccountInfoMut<'b>,
+        Q: AsRef<[u8]>,
+    {
+        let ix_sysvar = ix_sysvar.as_account_info();
+        let oracle_account = oracle_account.as_account_info_mut();
+
+        let data = Instructions::extract_ix_data_unchecked(ix_sysvar, instruction_index);
+        Self::write_unchecked(data, queue, oracle_account);
+    }
+
+    #[inline(always)]
+    #[allow(clippy::missing_safety_doc)] // Safety documentation is comprehensive above
+    #[cfg(not(feature = "pinocchio"))]
     pub fn write_from_ix_unchecked<'b, I, O, Q>(
         ix_sysvar: I,
         oracle_account: O,

--- a/solana/rust/switchboard-on-demand/src/on_demand/oracle_quote/quote_verifier.rs
+++ b/solana/rust/switchboard-on-demand/src/on_demand/oracle_quote/quote_verifier.rs
@@ -41,7 +41,7 @@ const SYSVAR_SLOT_LEN: u64 = 512;
 /// verification can be performed.
 ///
 /// The verifier accepts any type that implements `AsAccountInfo`, making it compatible
-/// with Anchor wrapper types like `AccountLoader`, `Sysvar`, etc., as well as pinocchio AccountInfo.
+/// with Anchor wrapper types like `AccountLoader`, `Sysvar`, etc., as well as pinocchio `AccountView`.
 ///
 /// # Example with Anchor Context
 /// ```rust,ignore
@@ -121,13 +121,13 @@ impl<'a> QuoteVerifier<'a> {
     /// be used to validate the signatures in the oracle quote.
     ///
     /// # Arguments
-    /// * `account` - Any type that implements `AsAccountInfo` (e.g., `AccountLoader`, direct `AccountInfo` reference, pinocchio AccountInfo)
+    /// * `account` - Any type that implements `AsAccountInfo` (e.g., `AccountLoader`, direct `AccountInfo` reference, pinocchio `AccountView`)
     ///
     /// # Example
     /// ```rust,ignore
     /// verifier.queue(&ctx.accounts.queue);  // Works with Anchor AccountLoader
     /// verifier.queue(&account_info);        // Works with AccountInfo reference
-    /// verifier.queue(&pinocchio_account);   // Works with pinocchio AccountInfo
+    /// verifier.queue(&pinocchio_account);   // Works with pinocchio AccountView
     /// ```
     #[inline(always)]
     pub fn queue(&mut self, account: &'a AccountInfo) -> &mut Self {
@@ -141,13 +141,13 @@ impl<'a> QuoteVerifier<'a> {
     /// in the oracle quote corresponds to a valid historical slot.
     ///
     /// # Arguments
-    /// * `sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<SlotHashes>`, direct `AccountInfo` reference, pinocchio AccountInfo)
+    /// * `sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<SlotHashes>`, direct `AccountInfo` reference, pinocchio `AccountView`)
     ///
     /// # Example
     /// ```rust,ignore
     /// verifier.slothash_sysvar(&ctx.accounts.slothashes);  // Works with Anchor Sysvar
     /// verifier.slothash_sysvar(&slothash_account);         // Works with AccountInfo reference
-    /// verifier.slothash_sysvar(&pinocchio_account);        // Works with pinocchio AccountInfo
+    /// verifier.slothash_sysvar(&pinocchio_account);        // Works with pinocchio AccountView
     /// ```
     #[inline(always)]
     pub fn slothash_sysvar(&mut self, sysvar: &'a AccountInfo) -> &mut Self {
@@ -161,13 +161,13 @@ impl<'a> QuoteVerifier<'a> {
     /// will be parsed to extract the oracle signatures and quote data.
     ///
     /// # Arguments
-    /// * `sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<Instructions>`, direct `AccountInfo` reference, pinocchio AccountInfo)
+    /// * `sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<Instructions>`, direct `AccountInfo` reference, pinocchio `AccountView`)
     ///
     /// # Example
     /// ```rust,ignore
     /// verifier.ix_sysvar(&ctx.accounts.instructions);  // Works with Anchor Sysvar
     /// verifier.ix_sysvar(&ix_account);                 // Works with AccountInfo reference
-    /// verifier.ix_sysvar(&pinocchio_account);          // Works with pinocchio AccountInfo
+    /// verifier.ix_sysvar(&pinocchio_account);          // Works with pinocchio AccountView
     /// ```
     #[inline(always)]
     pub fn ix_sysvar(&mut self, sysvar: &'a AccountInfo) -> &mut Self {
@@ -202,7 +202,7 @@ impl<'a> QuoteVerifier<'a> {
     ///
     /// # Arguments
     /// * `oracle_account` - Any type that implements `AsAccountInfo` containing the oracle quote data
-    ///   (e.g., `AccountLoader<SwitchboardQuote>`, direct `AccountInfo` reference, pinocchio AccountInfo)
+    ///   (e.g., `AccountLoader<SwitchboardQuote>`, direct `AccountInfo` reference, pinocchio `AccountView`)
     ///
     /// # Returns
     /// * `Ok(OracleQuote)` - Successfully verified oracle quote with feed data
@@ -226,7 +226,7 @@ impl<'a> QuoteVerifier<'a> {
     {
         let account_info = oracle_account.as_account_info();
 
-        let oracle_data = unsafe { account_info.borrow_data_unchecked() };
+        let oracle_data = unsafe { account_info.borrow_unchecked() };
 
         if oracle_data.len() < 40 {
             bail!(
@@ -410,7 +410,7 @@ impl<'a> QuoteVerifier<'a> {
     {
         let account_info = oracle_account.as_account_info();
 
-        let oracle_data = unsafe { account_info.borrow_data_unchecked() };
+        let oracle_data = unsafe { account_info.borrow_unchecked() };
 
         if oracle_data.len() < 40 {
             bail!(
@@ -508,7 +508,7 @@ impl<'a> QuoteVerifier<'a> {
 
         // Get queue data for oracle signing keys
         // Safely access queue data using RefCell borrow and try_from_bytes
-        let queue_buf = unsafe { borrow_account_data!(queue) };
+        let queue_buf = borrow_account_data!(queue);
         if queue_buf.len() != 6280 {
             bail!("Queue account too small: {} bytes", queue_buf.len());
         }
@@ -624,7 +624,7 @@ impl<'a> QuoteVerifier<'a> {
             *get_account_key!(slothash_sysvar),
             solana_program::sysvar::slot_hashes::ID
         ));
-        let slothash_data = unsafe { borrow_account_data!(slothash_sysvar) };
+        let slothash_data = borrow_account_data!(slothash_sysvar);
 
         // # Safety
         //
@@ -672,13 +672,13 @@ impl<'a> QuoteVerifier<'a> {
     /// be used to validate the signatures in the oracle quote.
     ///
     /// # Arguments
-    /// * `account` - Any type that implements `AsAccountInfo` (e.g., `AccountLoader`, direct `AccountInfo` reference, pinocchio AccountInfo)
+    /// * `account` - Any type that implements `AsAccountInfo` (e.g., `AccountLoader`, direct `AccountInfo` reference, pinocchio `AccountView`)
     ///
     /// # Example
     /// ```rust,ignore
     /// verifier.queue(&ctx.accounts.queue);  // Works with Anchor AccountLoader
     /// verifier.queue(&account_info);        // Works with AccountInfo reference
-    /// verifier.queue(&pinocchio_account);   // Works with pinocchio AccountInfo
+    /// verifier.queue(&pinocchio_account);   // Works with pinocchio AccountView
     /// ```
     #[inline(always)]
     pub fn queue<T>(&mut self, account: T) -> &mut Self
@@ -695,13 +695,13 @@ impl<'a> QuoteVerifier<'a> {
     /// in the oracle quote corresponds to a valid historical slot.
     ///
     /// # Arguments
-    /// * `sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<SlotHashes>`, direct `AccountInfo` reference, pinocchio AccountInfo)
+    /// * `sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<SlotHashes>`, direct `AccountInfo` reference, pinocchio `AccountView`)
     ///
     /// # Example
     /// ```rust,ignore
     /// verifier.slothash_sysvar(&ctx.accounts.slothashes);  // Works with Anchor Sysvar
     /// verifier.slothash_sysvar(&slothash_account);         // Works with AccountInfo reference
-    /// verifier.slothash_sysvar(&pinocchio_account);        // Works with pinocchio AccountInfo
+    /// verifier.slothash_sysvar(&pinocchio_account);        // Works with pinocchio AccountView
     /// ```
     #[inline(always)]
     pub fn slothash_sysvar<T>(&mut self, sysvar: T) -> &mut Self
@@ -718,13 +718,13 @@ impl<'a> QuoteVerifier<'a> {
     /// will be parsed to extract the oracle signatures and quote data.
     ///
     /// # Arguments
-    /// * `sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<Instructions>`, direct `AccountInfo` reference, pinocchio AccountInfo)
+    /// * `sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<Instructions>`, direct `AccountInfo` reference, pinocchio `AccountView`)
     ///
     /// # Example
     /// ```rust,ignore
     /// verifier.ix_sysvar(&ctx.accounts.instructions);  // Works with Anchor Sysvar
     /// verifier.ix_sysvar(&ix_account);                 // Works with AccountInfo reference
-    /// verifier.ix_sysvar(&pinocchio_account);          // Works with pinocchio AccountInfo
+    /// verifier.ix_sysvar(&pinocchio_account);          // Works with pinocchio AccountView
     /// ```
     #[inline(always)]
     pub fn ix_sysvar<T>(&mut self, sysvar: T) -> &mut Self
@@ -762,7 +762,7 @@ impl<'a> QuoteVerifier<'a> {
     ///
     /// # Arguments
     /// * `oracle_account` - Any type that implements `AsAccountInfo` containing the oracle quote data
-    ///   (e.g., `AccountLoader<SwitchboardQuote>`, direct `AccountInfo` reference, pinocchio AccountInfo)
+    ///   (e.g., `AccountLoader<SwitchboardQuote>`, direct `AccountInfo` reference, pinocchio `AccountView`)
     ///
     /// # Returns
     /// * `Ok(OracleQuote)` - Successfully verified oracle quote with feed data
@@ -791,7 +791,7 @@ impl<'a> QuoteVerifier<'a> {
         // # Safety: Account data is memory-mapped by Solana runtime and lives for the transaction duration
         // We're using unsafe to extend the lifetime from the temporary borrow to match the account parameter
         let oracle_data: &'data [u8] = unsafe {
-            let temp_borrow = account_info.borrow_data_unchecked();
+            let temp_borrow = account_info.borrow_unchecked();
             std::slice::from_raw_parts(temp_borrow.as_ptr(), temp_borrow.len())
         };
 
@@ -988,7 +988,7 @@ impl<'a> QuoteVerifier<'a> {
     {
         let account_info = oracle_account.as_account_info();
 
-        let oracle_data = account_info.borrow_data_unchecked();
+        let oracle_data = unsafe { account_info.borrow_unchecked() };
 
         if oracle_data.len() < 40 {
             bail!(
@@ -1273,10 +1273,8 @@ where
             INSTRUCTIONS_SYSVAR_ID
         ));
 
-        let num_instructions = unsafe {
-            let data = borrow_account_data!(ix_sysvar_account);
-            read_unaligned(data.as_ptr() as *const u16) as usize
-        };
+        let data = borrow_account_data!(ix_sysvar_account);
+        let num_instructions = unsafe { read_unaligned(data.as_ptr() as *const u16) as usize };
 
         // For get_instruction_relative(-1, ...), we want the previous instruction
         // Since instructions are 0-indexed, the previous instruction is at index (num_instructions - 1)

--- a/solana/rust/switchboard-on-demand/src/solana_compat.rs
+++ b/solana/rust/switchboard-on-demand/src/solana_compat.rs
@@ -8,7 +8,9 @@
 
 // Ensure only one Solana version is enabled
 #[cfg(all(feature = "solana-v2", feature = "solana-v3"))]
-compile_error!("Cannot enable both 'solana-v2' and 'solana-v3' features at the same time. Choose one.");
+compile_error!(
+    "Cannot enable both 'solana-v2' and 'solana-v3' features at the same time. Choose one."
+);
 
 // Ensure only one client version is enabled
 #[cfg(all(feature = "client", feature = "client-v3"))]
@@ -21,9 +23,9 @@ compile_error!("Cannot enable both 'client-v2' and 'client-v3' features at the s
 #[cfg(feature = "anchor")]
 pub use anchor_lang::solana_program;
 
-// When anchor is NOT enabled, use version-specific solana_program
-// v3 takes precedence when both v2 and v3 are enabled
-#[cfg(all(not(feature = "anchor"), feature = "solana-v2"))]
+// When anchor is NOT enabled, use version-specific solana_program.
+// A no-default-features build falls back to v2 program types.
+#[cfg(all(not(feature = "anchor"), not(feature = "solana-v3")))]
 pub use solana_program_v2 as solana_program;
 #[cfg(all(not(feature = "anchor"), feature = "solana-v3"))]
 pub use solana_program_v3 as solana_program;
@@ -44,19 +46,28 @@ pub use solana_sdk_v2 as solana_sdk;
 // Re-export them here to provide a consistent API
 
 // V2: these come from solana_sdk
-#[cfg(all(any(feature = "client", feature = "client-v2"), not(feature = "client-v3")))]
+#[cfg(all(
+    any(feature = "client", feature = "client-v2"),
+    not(feature = "client-v3")
+))]
 pub mod address_lookup_table {
     #[allow(deprecated)]
     pub use solana_sdk_v2::address_lookup_table::*;
 }
 
-#[cfg(all(any(feature = "client", feature = "client-v2"), not(feature = "client-v3")))]
+#[cfg(all(
+    any(feature = "client", feature = "client-v2"),
+    not(feature = "client-v3")
+))]
 pub mod compute_budget {
     #[allow(deprecated)]
     pub use solana_sdk_v2::compute_budget::*;
 }
 
-#[cfg(all(any(feature = "client", feature = "client-v2"), not(feature = "client-v3")))]
+#[cfg(all(
+    any(feature = "client", feature = "client-v2"),
+    not(feature = "client-v3")
+))]
 pub mod commitment_config {
     #[allow(deprecated)]
     pub use solana_sdk_v2::commitment_config::*;
@@ -142,13 +153,19 @@ extern "C" {
 #[cfg(feature = "anchor")]
 pub use solana_program_v2::address_lookup_table::AddressLookupTableAccount;
 
-// For v2, it's in solana_program
-#[cfg(all(feature = "solana-v2", not(feature = "solana-v3"), not(feature = "anchor")))]
+// For v2 and no-default builds, it's in solana_program
+#[cfg(all(not(feature = "solana-v3"), not(feature = "anchor")))]
 pub use solana_program::address_lookup_table::AddressLookupTableAccount;
 
 // For v3 when used with client-v3, get it from our v2-compat re-exported address_lookup_table module
 #[cfg(all(feature = "solana-v3", feature = "client-v3"))]
 pub use address_lookup_table::AddressLookupTableAccount;
+
+#[cfg(feature = "client-v3")]
+pub type MessageAddressLookupTableAccount = solana_message_v3::AddressLookupTableAccount;
+
+#[cfg(not(feature = "client-v3"))]
+pub type MessageAddressLookupTableAccount = AddressLookupTableAccount;
 
 /// Cluster type enum for specifying Solana network environments
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -162,4 +179,3 @@ pub enum ClusterType {
     /// Local development environment
     Development,
 }
-

--- a/solana/rust/switchboard-on-demand/src/solana_compat.rs
+++ b/solana/rust/switchboard-on-demand/src/solana_compat.rs
@@ -19,6 +19,9 @@ compile_error!("Cannot enable both 'client' and 'client-v3' features at the same
 #[cfg(all(feature = "client-v2", feature = "client-v3"))]
 compile_error!("Cannot enable both 'client-v2' and 'client-v3' features at the same time. Use 'client-v2' for Solana v2 or 'client-v3' for Solana v3.");
 
+#[cfg(all(feature = "pinocchio", not(any(feature = "solana-v2", feature = "solana-v3"))))]
+compile_error!("The 'pinocchio' feature requires either 'solana-v2' or 'solana-v3'. Enable one Solana version feature explicitly.");
+
 // When anchor is enabled, use anchor's solana_program (v2.x)
 #[cfg(feature = "anchor")]
 pub use anchor_lang::solana_program;

--- a/solana/rust/switchboard-on-demand/src/sysvar/clock.rs
+++ b/solana/rust/switchboard-on-demand/src/sysvar/clock.rs
@@ -3,11 +3,11 @@ use crate::{borrow_account_data, check_pubkey_eq, get_account_key, solana_progra
 /// Optimized function to extract the slot value from a Clock sysvar.
 ///
 /// This function extracts just the slot value from any type that implements
-/// `AsAccountInfo`, making it compatible with Anchor's `Sysvar<Clock>` wrapper and pinocchio AccountInfo.
+/// `AsAccountInfo`, making it compatible with Anchor's `Sysvar<Clock>` wrapper and pinocchio `AccountView`.
 /// This is more efficient than parsing the entire Clock struct when you only need the slot.
 ///
 /// # Arguments
-/// * `clock_sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<Clock>`, direct `AccountInfo` reference, pinocchio AccountInfo)
+/// * `clock_sysvar` - Any type that implements `AsAccountInfo` (e.g., `Sysvar<Clock>`, direct `AccountInfo` reference, pinocchio `AccountView`)
 ///
 /// # Returns
 /// The current slot value as a `u64`.
@@ -40,10 +40,8 @@ where
         *get_account_key!(clock_sysvar.as_account_info()),
         solana_program::sysvar::clock::ID
     ));
-    unsafe {
-        let clock_data = borrow_account_data!(clock_sysvar.as_account_info());
-        core::ptr::read_unaligned(clock_data.as_ptr() as *const u64)
-    }
+    let clock_data = borrow_account_data!(clock_sysvar.as_account_info());
+    unsafe { core::ptr::read_unaligned(clock_data.as_ptr() as *const u64) }
 }
 
 crate::cfg_client! {

--- a/solana/rust/switchboard-on-demand/src/sysvar/ix_sysvar.rs
+++ b/solana/rust/switchboard-on-demand/src/sysvar/ix_sysvar.rs
@@ -3,9 +3,7 @@ use core::ptr::read_unaligned;
 use crate::solana_compat::ed25519_program::ID as ED25519_PROGRAM_ID;
 use crate::solana_compat::sysvar::instructions::ID as INSTRUCTIONS_SYSVAR_ID;
 
-use crate::{
-    borrow_account_data, check_pubkey_eq, get_account_key, AsAccountInfo, Pubkey,
-};
+use crate::{borrow_account_data, check_pubkey_eq, get_account_key, AsAccountInfo, Pubkey};
 
 /// Optimized wrapper for Solana's Instructions sysvar with fast instruction data extraction.
 ///
@@ -50,10 +48,10 @@ impl Instructions {
             *get_account_key!(ix_sysvar),
             INSTRUCTIONS_SYSVAR_ID
         ));
-        unsafe {
-            let data = borrow_account_data!(ix_sysvar);
-            let base = data.as_ptr();
+        let data = borrow_account_data!(ix_sysvar);
+        let base = data.as_ptr();
 
+        unsafe {
             // Read num_instructions from offset
             let num_instructions = read_unaligned(base as *const u16) as usize;
 
@@ -128,9 +126,10 @@ impl Instructions {
         T: AsAccountInfo<'a>,
     {
         let ix_sysvar = ix_sysvar.as_account_info();
+        let data = borrow_account_data!(ix_sysvar);
+        let base = data.as_ptr();
+
         unsafe {
-            let data = borrow_account_data!(ix_sysvar);
-            let base = data.as_ptr();
             let start_offset = read_unaligned(base.add(2 + (idx << 1)) as *const u16) as usize;
             let mut p = base.add(start_offset);
             let num_accounts = read_unaligned(p as *const u16) as usize;


### PR DESCRIPTION
## Summary

Prepare release artifacts for the three SDK releases without publishing to npm or crates.io:

- `@switchboard-xyz/on-demand@3.10.4`
- `switchboard-on-demand-client@0.6.0`
- `switchboard-on-demand@0.13.0`

This branch has been corrected to follow canonical `sbv3` state for `switchboard-on-demand`. `sbv3 origin/main` is already at `0.13.0` from `sbv3#1013`, so the stale `0.12.2` release target was removed.

## Source-of-Truth Check

Current registry latest:

- npm `@switchboard-xyz/on-demand`: `3.10.3`
- npm `@switchboard-xyz/common`: `5.8.2`
- crates.io `switchboard-on-demand`: `0.12.1`
- crates.io `switchboard-on-demand-client`: `0.5.1`

Manifest state checked before correction:

- `sbv3 origin/main` `rust/switchboard-on-demand`: `0.13.0`
- `sbv3 origin/main` `rust/switchboard-on-demand-client`: `0.5.1`
- `sbv3 origin/main` `javascript/on-demand`: `3.10.2`
- `switchboard-sdk origin/main` `solana/rust/switchboard-on-demand`: `0.12.1`
- this PR `solana/rust/switchboard-on-demand`: `0.13.0`
- this PR `solana/rust/switchboard-on-demand-client`: `0.6.0`
- this PR `solana/javascript/on-demand`: `3.10.4`

Pre-release guardrail: release-note versions must match the canonical `sbv3` manifest and the final `switchboard-sdk` release branch manifest before publishing.

## Changes

- Adaptively ported merged `sbv3#1015` into `solana/javascript/on-demand` while preserving existing `solanaCluster` network-resolution behavior.
- Added EVM and Solana randomness oracle selection smoke tests and wired them into `pnpm test`.
- Bumped `@switchboard-xyz/on-demand` to `3.10.4`, updated `@switchboard-xyz/common` to `^5.8.2`, and added direct `@noble/hashes` dependency for the ported EVM `sha3` import.
- Confirmed `switchboard-on-demand-client` remains `0.6.0`; fixed the release guardrail mirror path, README path, doctests, and Cargo clean-metadata handling.
- Synced the `sbv3#1013` `switchboard-on-demand@0.13.0` source changes into `solana/rust/switchboard-on-demand`, including the Pinocchio AccountView migration and compatible Pinocchio 0.11.x dependency range.
- Updated `Cargo.lock`, excluded the tracked `.env` from crate packaging, and kept the existing feature compatibility fixes from this release-prep branch.
- Mirrored the corrected canonical `SDK_RELEASE_NOTES.md` from the companion `sbv3` branch.

## Verification

Earlier release-prep verification for the unchanged npm package and client crate was retained:

- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile`
- `pnpm run check-types`
- `pnpm test`
- `pnpm exec tsx test/evmRandomnessOracleSelection.smoke.ts`
- `pnpm exec tsx test/solanaRandomnessOracleSelection.smoke.ts`
- `pnpm publish --dry-run --no-git-checks`
- `cargo test --manifest-path solana/rust/switchboard-on-demand-client/Cargo.toml`
- `cargo publish --dry-run --manifest-path solana/rust/switchboard-on-demand-client/Cargo.toml`
- temporary local tag + `solana/rust/switchboard-on-demand-client/scripts/verify-crate-release.sh`, then deleted the tag

Re-run for the corrected `switchboard-on-demand@0.13.0` branch:

- `cargo test --manifest-path solana/rust/switchboard-on-demand/Cargo.toml` passed: 20 tests
- `cargo check --manifest-path solana/rust/switchboard-on-demand/Cargo.toml --no-default-features` passed
- `cargo check --manifest-path solana/rust/switchboard-on-demand/Cargo.toml --features client` passed
- `cargo check --manifest-path solana/rust/switchboard-on-demand/Cargo.toml --no-default-features --features client-v2` passed
- `cargo check --manifest-path solana/rust/switchboard-on-demand/Cargo.toml --no-default-features --features client-v3` was killed twice with exit 137 and no Rust diagnostic in the local container
- `cargo package --list --manifest-path solana/rust/switchboard-on-demand/Cargo.toml` passed; `.env` is absent from the 87-file package list
- `cargo publish --dry-run --manifest-path solana/rust/switchboard-on-demand/Cargo.toml` packaged `switchboard-on-demand v0.13.0`, then was killed with exit 137 during packaged-crate verification and no Rust diagnostic
- `cargo publish --dry-run --no-verify --manifest-path solana/rust/switchboard-on-demand/Cargo.toml` passed; Cargo packaged and dry-run-uploaded `switchboard-on-demand v0.13.0`, then aborted upload because this was a dry run
- confirmed canonical `sbv3/SDK_RELEASE_NOTES.md` and this mirrored `SDK_RELEASE_NOTES.md` match exactly with `cmp`
- final generated-artifact cleanup completed; worktree status is clean

Warnings observed: Cargo reports `keccak v0.1.5` is yanked in the lockfile; the client crate manifest still lacks documentation/homepage/repository metadata.

No real npm or crates.io publish was run.
