### PR TITLE
[codex] Document SDK feed parameter units

### DIFF
--- a/aptos/README.md
+++ b/aptos/README.md
@@ -155,10 +155,10 @@ const minSampleSize = 1;
 const maxStalenessSeconds = 60;
 
 // If jobs diverge more than 1%, don't allow the feed to produce a valid update
-const maxVariance = 1e9;
+const maxVariance = 1e9; // 1%, scaled by 1e9 for this chain parameter
 
-// Require only 1 job response
-const minJobResponses = 1;
+// Require only 1 job response (unscaled count)
+const minJobResponses = 1; // unscaled job/source quorum
 
 //==========================================================
 // Feed Initialization On-Chain

--- a/aptos/on_demand/scripts/ts/devnet_aggregator_flow.ts
+++ b/aptos/on_demand/scripts/ts/devnet_aggregator_flow.ts
@@ -64,7 +64,7 @@ const aggregatorInitTx = await Aggregator.initTx(client, signer, {
   name: "BTC/USD",
   minSampleSize: 1,
   maxStalenessSeconds: 60,
-  maxVariance: 1e9,
+  maxVariance: 1e9, // 1%, scaled by 1e9
   feedHash:
     "0x558be89a28d20c32f4cd427dd0dc05229ffefb8c17396124d0bbb0e5efd0a04f",
   minResponses: 1,
@@ -120,4 +120,3 @@ const resTx = await aptos.signAndSubmitTransaction({
 const resultTx = await waitForTx(aptos, resTx.hash);
 
 console.log("Transaction result:", resultTx);
-

--- a/aptos/on_demand/scripts/ts/mainnet_aggregator_flow.ts
+++ b/aptos/on_demand/scripts/ts/mainnet_aggregator_flow.ts
@@ -63,7 +63,7 @@ console.log("Switchboard address:", switchboardAddress);
 //   name: "BTC/USD",
 //   minSampleSize: 1,
 //   maxStalenessSeconds: 60,
-//   maxVariance: 1e9,
+//   maxVariance: 1e9, // 1%, scaled by 1e9
 //   feedHash:
 //     "0x937efd0ba38a4db89364ea2c07de8873e443955b893ba5bcb2edaa611fb13a78",
 //   minResponses: 1,

--- a/aptos/on_demand/scripts/ts/porto_aggregator_flow.ts
+++ b/aptos/on_demand/scripts/ts/porto_aggregator_flow.ts
@@ -62,7 +62,7 @@ const aggregatorInitTx = await Aggregator.initTx(client, signer, {
   name: "BTC/USD",
   minSampleSize: 1,
   maxStalenessSeconds: 60,
-  maxVariance: 1e9,
+  maxVariance: 1e9, // 1%, scaled by 1e9
   feedHash:
     "0x558be89a28d20c32f4cd427dd0dc05229ffefb8c17396124d0bbb0e5efd0a04f",
   minResponses: 1,

--- a/aptos/on_demand/scripts/ts/testnet_aggregator_flow.ts
+++ b/aptos/on_demand/scripts/ts/testnet_aggregator_flow.ts
@@ -63,7 +63,7 @@ console.log(await queue.loadOracles());
 //   name: "BTC/USD",
 //   minSampleSize: 1,
 //   maxStalenessSeconds: 60,
-//   maxVariance: 1e9,
+//   maxVariance: 1e9, // 1%, scaled by 1e9
 //   feedHash:
 //     "0x558be89a28d20c32f4cd427dd0dc05229ffefb8c17396124d0bbb0e5efd0a04f",
 //   minResponses: 1,

--- a/javascript/common/README.md
+++ b/javascript/common/README.md
@@ -73,3 +73,9 @@ import { simulateOracleJobs } from "@switchboard-xyz/common";
 const result = await simulateOracleJobs([oracleJob]);
 console.log(result);
 ```
+
+## Feed Parameter Units
+
+Raw v2 `OracleFeed.maxJobRangePct` values are fixed-point percentages scaled by `1e9`: `1_000_000_000` means `1%`. `minJobResponses` and `minOracleSamples` are unscaled counts.
+
+Some SDK gateway helpers accept human-percent `maxVariance` values and scale them internally, while low-level Crossbar/gateway request bodies expect already-scaled integers. See [Feed Parameter Units](https://docs.switchboard.xyz/custom-feeds/advanced-feed-configuration/feed-parameter-units) before copying validation values between APIs.

--- a/javascript/common/src/crossbar-client.ts
+++ b/javascript/common/src/crossbar-client.ts
@@ -51,8 +51,8 @@ export class CrossbarClient {
   /**
    * Create a FeedRequestV1 object
    * @param {string[]} jobsB64Encoded - Base64 encoded oracle jobs
-   * @param {number} maxVariance - Maximum variance allowed for the feed
-   * @param {number} minResponses - Minimum number of oracle responses required
+   * @param {number} maxVariance - Maximum variance allowed for the feed, already scaled by 1e9 (1_000_000_000 = 1%)
+   * @param {number} minResponses - Minimum number of job responses required, unscaled
    * @returns {FeedRequest} - A FeedRequestV1 object
    */
   static createFeedRequestV1(
@@ -670,7 +670,7 @@ export class CrossbarClient {
    * // Using FeedRequestV1
    * const feedRequestV1 = CrossbarClient.createFeedRequestV1(
    *   ['base64EncodedJob1', 'base64EncodedJob2'],
-   *   1000000, // maxVariance
+   *   1_000_000_000, // maxVariance: 1%, scaled by 1e9
    *   3        // minResponses
    * );
    *

--- a/javascript/common/src/evm-utils.ts
+++ b/javascript/common/src/evm-utils.ts
@@ -246,7 +246,7 @@ export class EVMUtils {
    * Convert a Surge update to EVM encoded format
    * Format: slot(8) + timestamp(8) + numFeeds(1) + numSigs(1) + feeds(49*n) + sigs(65*m)
    * @param surgeUpdate - The SurgeUpdate from Switchboard Surge
-   * @param options - Optional parameters including minOracleSamples
+   * @param options - Optional parameters including minOracleSamples, an unscaled oracle-sample quorum
    * @returns Hex-encoded string in EVM format
    */
   static convertSurgeUpdateToEvmFormat(

--- a/javascript/common/src/gateway.ts
+++ b/javascript/common/src/gateway.ts
@@ -198,6 +198,8 @@ export class Gateway {
    * REST API endpoint: /api/v1/fetch_signatures_consensus
    *
    * @param feedConfigs Array of feed configurations to fetch signatures for.
+   * V1 feed config `maxVariance` is a human percent (1 = 1%) and is scaled by 1e9 here.
+   * V2 feed config `feed.maxJobRangePct` must already be a raw scaled integer (1_000_000_000 = 1%).
    * @param useTimestamp Whether to use the timestamp in the response & to encode update signature.
    * @param numSignatures The number of oracles to fetch signatures from.
    * @param useEd25519 Whether to use Ed25519 signatures instead of secp256k1.

--- a/javascript/common/src/types/chains.ts
+++ b/javascript/common/src/types/chains.ts
@@ -33,8 +33,11 @@ export interface SuiAggregatorResponse {
   results: SuiResult[];
   feedConfigs: {
     feedHash: string;
+    /** Percent scaled by 1e9 (1_000_000_000 = 1%). */
     maxVariance: number;
+    /** Unscaled job/source quorum. */
     minResponses: number;
+    /** Unscaled oracle/sample quorum. */
     minSampleSize: number;
   };
   failures: string[];
@@ -68,8 +71,11 @@ export interface IotaAggregatorResponse {
   results: IotaResult[];
   feedConfigs: {
     feedHash: string;
+    /** Percent scaled by 1e9 (1_000_000_000 = 1%). */
     maxVariance: number;
+    /** Unscaled job/source quorum. */
     minResponses: number;
+    /** Unscaled oracle/sample quorum. */
     minSampleSize: number;
   };
   failures: string[];

--- a/javascript/common/src/types/crossbar.ts
+++ b/javascript/common/src/types/crossbar.ts
@@ -97,7 +97,9 @@ export type OracleInfo = {
 export type FetchSignaturesRequest = {
   feedHash: string;
   numSignatures: number;
+  /** Maximum variance already scaled by 1e9 (1_000_000_000 = 1%). */
   maxVariance: number;
+  /** Minimum number of job responses required, unscaled. */
   minResponses: number;
   useTimestamp?: boolean;
   gateway?: string;
@@ -111,7 +113,9 @@ export type FetchSignaturesRequest = {
 export type FeedRequest = {
   // For FeedRequestV1
   jobsB64Encoded?: string[];
+  /** Maximum variance already scaled by 1e9 (1_000_000_000 = 1%). */
   maxVariance?: number;
+  /** Minimum number of job responses required, unscaled. */
   minResponses?: number;
   // For FeedRequestV2
   feedProtoB64?: string;

--- a/javascript/common/src/types/gateway.ts
+++ b/javascript/common/src/types/gateway.ts
@@ -8,9 +8,9 @@ import type { IOracleFeed, IOracleJob } from '../protos.js';
  * Configuration for a feed request to oracle operators (V1)
  */
 export type FeedRequestV1 = {
-  /** Maximum allowed variance between oracle responses (e.g., 1.0 = 100%) */
+  /** Maximum allowed variance as a human percent; Gateway helpers scale by 1e9 (1.0 = 1%). */
   maxVariance?: number;
-  /** Minimum number of oracle responses required */
+  /** Minimum number of job responses required, unscaled. */
   minResponses?: number;
   /** Array of oracle job definitions */
   jobs: IOracleJob[];
@@ -21,7 +21,7 @@ export type FeedRequestV1 = {
  * Uses protobuf-encoded feed instead of individual job definitions
  */
 export type FeedRequestV2 = {
-  /** Oracle feed proto definition */
+  /** Oracle feed proto definition. feed.maxJobRangePct is already scaled by 1e9 (1_000_000_000 = 1%). */
   feed: IOracleFeed;
 };
 

--- a/solana/javascript/on-demand/README.md
+++ b/solana/javascript/on-demand/README.md
@@ -48,6 +48,10 @@ const [pullIx] = await feedAccount.fetchUpdateIx({ numSignatures: 3 });
 ## Getting Started
 To start building your own on-demand oracle with Switchboard, you can refer to the oracle specification in our [documentation](https://protos.docs.switchboard.xyz/protos/OracleJob).
 
+### Feed Parameter Units
+
+Solana helper methods such as `PullFeed.initIx` and `PullFeed.setConfigsIx` accept human-percent `maxVariance` values and scale them by `1e9` internally. Raw v2 `OracleFeed.maxJobRangePct` values are already scaled integers, so `1_000_000_000` means `1%`. `minJobResponses` and `minOracleSamples` are unscaled counts. See [Feed Parameter Units](https://docs.switchboard.xyz/custom-feeds/advanced-feed-configuration/feed-parameter-units).
+
 ### Example Code Snippet:
 ```typescript
 const [pullIx] = await feedAccount.fetchUpdateIx({ numSignatures: 3 });
@@ -176,4 +180,3 @@ const feedHashes = [
   Buffer.from('1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', 'hex')
 ];
 ```
-

--- a/solana/javascript/on-demand/src/accounts/pullFeed.ts
+++ b/solana/javascript/on-demand/src/accounts/pullFeed.ts
@@ -74,7 +74,9 @@ export interface PullFeedAccountData {
   feedHash: Uint8Array;
   initializedAt: BN;
   permissions: BN;
+  /** Stored maximum variance scaled by 1e9. */
   maxVariance: BN;
+  /** Unscaled job/source quorum. */
   minResponses: number;
   name: Uint8Array;
   sampleSize: number;
@@ -186,7 +188,7 @@ async function checkNeedsInit(
  * await pullFeed.initIx({
  *   name: "BTC/USD",
  *   queue: queuePubkey,
- *   maxVariance: 1.0,
+ *   maxVariance: 1.0, // 1%; this helper scales by 1e9 internally
  *   minResponses: 3,
  *   feedHash: jobHash,
  * });
@@ -202,7 +204,9 @@ export class PullFeed {
   pubkey: web3.PublicKey;
   configs: {
     queue: web3.PublicKey;
+    /** Human percent; init/set helpers scale by 1e9 internally. */
     maxVariance: number;
+    /** Unscaled job/source quorum. */
     minResponses: number;
     feedHash: Buffer;
     minSampleSize: number;
@@ -302,8 +306,11 @@ export class PullFeed {
     params: {
       name: string;
       queue: web3.PublicKey;
+      /** Human percent; scaled by 1e9 internally. */
       maxVariance: number;
+      /** Unscaled job/source quorum. */
       minResponses: number;
+      /** Unscaled oracle/sample quorum. */
       minSampleSize: number;
       maxStaleness: number;
       permitWriteByAuthority?: boolean;
@@ -398,9 +405,9 @@ export class PullFeed {
    * @param {Program} program - The Anchor program instance.
    * @param {PublicKey} queue - The queue account public key.
    * @param {Array<IOracleJob>} jobs - The oracle jobs to execute.
-   * @param {number} maxVariance - The maximum variance allowed for the feed.
-   * @param {number} minResponses - The minimum number of job responses required.
-   * @param {number} minSampleSize - The minimum number of samples required for setting feed value.
+   * @param {number} maxVariance - The maximum variance allowed for the feed as a human percent; scaled by 1e9 internally.
+   * @param {number} minResponses - The minimum number of job responses required, unscaled.
+   * @param {number} minSampleSize - The minimum number of samples required for setting feed value, unscaled.
    * @param {number} maxStaleness - The maximum number of slots that can pass before a feed value is considered stale.
    * @returns {Promise<web3.TransactionInstruction>} A promise that resolves to the transaction instruction.
    */
@@ -500,9 +507,9 @@ export class PullFeed {
    * @param params
    * @param params.feedHash - The hash of the feed as a `Uint8Array` or hexadecimal `string`. Only results signed with this hash will be accepted.
    * @param params.authority - The authority of the feed.
-   * @param params.maxVariance - The maximum variance allowed for the feed.
-   * @param params.minResponses - The minimum number of responses required.
-   * @param params.minSampleSize - The minimum number of samples required for setting feed value.
+   * @param params.maxVariance - The maximum variance allowed for the feed as a human percent; scaled by 1e9 internally.
+   * @param params.minResponses - The minimum number of responses required, unscaled.
+   * @param params.minSampleSize - The minimum number of samples required for setting feed value, unscaled.
    * @param params.maxStaleness - The maximum number of slots that can pass before a feed value is considered stale.
    * @returns A promise that resolves to the transaction instruction to set feed configs.
    */
@@ -649,7 +656,9 @@ export class PullFeed {
    */
   async loadConfigs(force?: boolean): Promise<{
     queue: web3.PublicKey;
+    /** Human percent, converted from the stored 1e9-scaled value. */
     maxVariance: number;
+    /** Unscaled job/source quorum. */
     minResponses: number;
     feedHash: Buffer;
     minSampleSize: number;

--- a/solana/javascript/on-demand/src/accounts/queue.ts
+++ b/solana/javascript/on-demand/src/accounts/queue.ts
@@ -1133,17 +1133,17 @@ export class Queue {
    * );
    *
    * // Using OracleFeed objects
-   * const btcFeed: IOracleFeed = {
-   *   name: 'BTC/USD Price Feed',
-   *   jobs: [btcJob1, btcJob2],
-   *   minOracleSamples: 3,
+ * const btcFeed: IOracleFeed = {
+ *   name: 'BTC/USD Price Feed',
+ *   jobs: [btcJob1, btcJob2],
+ *   minOracleSamples: 3, // unscaled oracle-sample quorum
    *   // ... other feed properties
    * };
    *
-   * const ethFeed: IOracleFeed = {
-   *   name: 'ETH/USD Price Feed',
-   *   jobs: [ethJob1, ethJob2],
-   *   minOracleSamples: 3,
+ * const ethFeed: IOracleFeed = {
+ *   name: 'ETH/USD Price Feed',
+ *   jobs: [ethJob1, ethJob2],
+ *   minOracleSamples: 3, // unscaled oracle-sample quorum
    * };
    *
    * const feedsIx = await queue.fetchQuoteIx(
@@ -1416,17 +1416,17 @@ export class Queue {
    * );
    *
    * // Using OracleFeed objects
-   * const btcFeed: IOracleFeed = {
-   *   name: 'BTC/USD Price Feed',
-   *   jobs: [btcJob1, btcJob2],
-   *   minOracleSamples: 3,
+ * const btcFeed: IOracleFeed = {
+ *   name: 'BTC/USD Price Feed',
+ *   jobs: [btcJob1, btcJob2],
+ *   minOracleSamples: 3, // unscaled oracle-sample quorum
    *   // ... other feed properties
    * };
    *
-   * const ethFeed: IOracleFeed = {
-   *   name: 'ETH/USD Price Feed',
-   *   jobs: [ethJob1, ethJob2],
-   *   minOracleSamples: 3,
+ * const ethFeed: IOracleFeed = {
+ *   name: 'ETH/USD Price Feed',
+ *   jobs: [ethJob1, ethJob2],
+ *   minOracleSamples: 3, // unscaled oracle-sample quorum
    * };
    *
    * const instructionsFromFeeds = await queue.fetchManagedUpdateIxs(

--- a/solana/javascript/on-demand/src/classes/oracleQuote.ts
+++ b/solana/javascript/on-demand/src/classes/oracleQuote.ts
@@ -24,12 +24,14 @@ export type QuoteSourceScheme = 'oracle' | 'authority';
 export interface FeedInfo {
   feedHash: Buffer;
   value: bigint;
+  /** Unscaled oracle/signature quorum for this feed. */
   minOracleSamples: number;
 }
 
 export interface AuthorityFeedInfoInput {
   feedHash: string | Buffer;
   value: bigint;
+  /** Unscaled oracle/signature quorum for this feed. */
   minOracleSamples?: number;
 }
 
@@ -60,6 +62,7 @@ export interface SwitchboardQuoteJSON {
   feeds: Array<{
     feedHash: string;
     value: string;
+    /** Unscaled oracle/signature quorum for this feed. */
     minOracleSamples: number;
   }>;
   oracleIdxs: number[];

--- a/solana/javascript/on-demand/src/evm/index.ts
+++ b/solana/javascript/on-demand/src/evm/index.ts
@@ -38,8 +38,8 @@ export * as message from './message.js';
 export interface FeedUpdateCommonOptions {
   jobs: OracleJob[]; // Array of job definitions
   numSignatures?: number; // Number of signatures to fetch
-  maxVariance?: number; // Maximum variance allowed for the feed
-  minResponses?: number; // Minimum number of responses to consider the feed valid
+  maxVariance?: number; // Maximum variance scaled by 1e9 (1e9 = 1%)
+  minResponses?: number; // Minimum number of responses to consider the feed valid, unscaled
   recentHash?: string; // Hex string of length 64 (32 bytes) which does not start with 0x
   aggregatorId?: string; // Specify the aggregator ID if the feed already exists
   blockNumber?: number; // The block number
@@ -109,7 +109,9 @@ export interface FetchResultsArgs {
   feedIds: string[];
   chainId: number;
   crossbarUrl?: string;
+  /** Minimum number of responses, unscaled. */
   minResponses?: number;
+  /** Maximum variance scaled by 1e9 (1e9 = 1%). */
   maxVariance?: number;
   numSignatures?: number;
   syncOracles?: boolean;
@@ -122,7 +124,9 @@ export interface FetchResultArgs {
   feedId: string;
   chainId: number;
   crossbarUrl?: string;
+  /** Minimum number of responses, unscaled. */
   minResponses?: number;
+  /** Maximum variance scaled by 1e9 (1e9 = 1%). */
   maxVariance?: number;
   numSignatures?: number;
   syncOracles?: boolean;
@@ -628,8 +632,8 @@ export async function fetchRandomness({
  * @param crossbarUrl The Crossbar URL
  * @param chainId The chain ID
  * @param feedId The feed ID
- * @param minResponses Minimum number of responses
- * @param maxVariance Maximum variance
+ * @param minResponses Minimum number of responses, unscaled
+ * @param maxVariance Maximum variance scaled by 1e9 (1e9 = 1%)
  * @param numSignatures Number of signatures
  * @param syncOracles Sync oracles
  * @param syncGuardians Sync guardians

--- a/solana/rust/switchboard-on-demand-client/README.md
+++ b/solana/rust/switchboard-on-demand-client/README.md
@@ -18,6 +18,8 @@ The script refuses to package from a dirty tree, refuses non-`main` branches unl
 ## Gateways
 The frontend to interact with Switchboard oracles.
 
+Gateway helper parameters named `max_variance` accept human percentages and scale by `1e9` before sending gateway requests. Raw v2 `OracleFeed.max_job_range_pct` values are already scaled integers, so `1_000_000_000` means `1%`. `min_job_responses` and `min_oracle_samples` are unscaled counts. See [Feed Parameter Units](https://docs.switchboard.xyz/custom-feeds/advanced-feed-configuration/feed-parameter-units).
+
 ## Example
 
 ```rust

--- a/solana/rust/switchboard-on-demand-client/src/crossbar.rs
+++ b/solana/rust/switchboard-on-demand-client/src/crossbar.rs
@@ -170,8 +170,11 @@ pub struct SuiOracleResult {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SuiFeedConfigs {
     pub feedHash: String,
+    /// Percent scaled by 1e9 (1_000_000_000 = 1%).
     pub maxVariance: u64,
+    /// Unscaled job/source quorum.
     pub minResponses: u64,
+    /// Unscaled oracle/sample quorum.
     pub minSampleSize: u64,
 }
 

--- a/solana/rust/switchboard-on-demand-client/src/gateway.rs
+++ b/solana/rust/switchboard-on-demand-client/src/gateway.rs
@@ -185,8 +185,8 @@ impl Gateway {
     /// * `params.recent_hash` - The recent hash of the feed
     /// * `params.encoded_jobs` - The encoded jobs
     /// * `params.num_signatures` - The number of signatures to fetch
-    /// * `params.max_variance` - The maximum variance
-    /// * `params.min_responses` - The minimum number of responses
+    /// * `params.max_variance` - The maximum variance as a human percent; scaled by 1e9 internally
+    /// * `params.min_responses` - The minimum number of responses, unscaled
     /// * `params.use_timestamp` - Whether to use the timestamp
     /// # Returns
     /// * `Result<FeedEvalResponseSingle, reqwest::Error>`
@@ -368,7 +368,9 @@ pub struct FetchSignaturesParams {
     pub recent_hash: Option<String>,
     pub encoded_jobs: Vec<String>,
     pub num_signatures: u32,
+    /// Human percent; scaled by 1e9 before sending the gateway request.
     pub max_variance: Option<u32>,
+    /// Unscaled job/source quorum.
     pub min_responses: Option<u32>,
     pub use_timestamp: Option<bool>,
 }
@@ -376,7 +378,9 @@ pub struct FetchSignaturesParams {
 #[derive(Debug, Clone)]
 pub struct FeedConfig {
     pub encoded_jobs: Vec<String>,
+    /// Human percent; scaled by 1e9 before sending the gateway request.
     pub max_variance: Option<u32>,
+    /// Unscaled job/source quorum.
     pub min_responses: Option<u32>,
 }
 
@@ -384,9 +388,9 @@ pub struct FeedConfig {
 pub struct BatchFeedRequest {
     /// Vec of jobs to process. Each group is equivalent to 1 feed.
     pub jobs_b64_encoded: Vec<String>,
-    /// Allowed variance in the feed values
+    /// Allowed variance in the feed values, already scaled by 1e9
     pub max_variance: u64,
-    /// Minimum number of responses required for the feed
+    /// Minimum number of responses required for the feed, unscaled
     pub min_responses: u32,
 }
 

--- a/solana/rust/switchboard-on-demand/README.md
+++ b/solana/rust/switchboard-on-demand/README.md
@@ -38,6 +38,10 @@ Ensure you have the following installed:
 - Cargo
 - Solana CLI tools (if interacting directly with the Solana blockchain)
 
+### Feed Parameter Units
+
+Solana gateway helper parameters named `max_variance` accept human percentages and scale by `1e9` before sending gateway requests. Raw v2 `OracleFeed.max_job_range_pct` values are already scaled integers, so `1_000_000_000` means `1%`. `min_job_responses` and `min_oracle_samples` are unscaled counts. See [Feed Parameter Units](https://docs.switchboard.xyz/custom-feeds/advanced-feed-configuration/feed-parameter-units).
+
 ### Installation
 
 Add `switchboard-on-demand` to your `Cargo.toml`:

--- a/solana/rust/switchboard-on-demand/src/client/crossbar.rs
+++ b/solana/rust/switchboard-on-demand/src/client/crossbar.rs
@@ -124,8 +124,11 @@ pub struct SuiOracleResult {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SuiFeedConfigs {
     pub feedHash: String,
+    /// Percent scaled by 1e9 (1_000_000_000 = 1%).
     pub maxVariance: u64,
+    /// Unscaled job/source quorum.
     pub minResponses: u64,
+    /// Unscaled oracle/sample quorum.
     pub minSampleSize: u64,
 }
 

--- a/solana/rust/switchboard-on-demand/src/client/gateway.rs
+++ b/solana/rust/switchboard-on-demand/src/client/gateway.rs
@@ -185,8 +185,8 @@ impl Gateway {
     /// * `params.recent_hash` - The recent hash of the feed
     /// * `params.encoded_jobs` - The encoded jobs
     /// * `params.num_signatures` - The number of signatures to fetch
-    /// * `params.max_variance` - The maximum variance
-    /// * `params.min_responses` - The minimum number of responses
+    /// * `params.max_variance` - The maximum variance as a human percent; scaled by 1e9 internally
+    /// * `params.min_responses` - The minimum number of responses, unscaled
     /// * `params.use_timestamp` - Whether to use the timestamp
     /// # Returns
     /// * `Result<FeedEvalResponseSingle, reqwest::Error>`
@@ -368,7 +368,9 @@ pub struct FetchSignaturesParams {
     pub recent_hash: Option<String>,
     pub encoded_jobs: Vec<String>,
     pub num_signatures: u32,
+    /// Human percent; scaled by 1e9 before sending the gateway request.
     pub max_variance: Option<u32>,
+    /// Unscaled job/source quorum.
     pub min_responses: Option<u32>,
     pub use_timestamp: Option<bool>,
 }
@@ -376,7 +378,9 @@ pub struct FetchSignaturesParams {
 #[derive(Debug, Clone)]
 pub struct FeedConfig {
     pub encoded_jobs: Vec<String>,
+    /// Human percent; scaled by 1e9 before sending the gateway request.
     pub max_variance: Option<u32>,
+    /// Unscaled job/source quorum.
     pub min_responses: Option<u32>,
 }
 
@@ -384,9 +388,9 @@ pub struct FeedConfig {
 pub struct BatchFeedRequest {
     /// Vec of jobs to process. Each group is equivalent to 1 feed.
     pub jobs_b64_encoded: Vec<String>,
-    /// Allowed variance in the feed values
+    /// Allowed variance in the feed values, already scaled by 1e9
     pub max_variance: u64,
-    /// Minimum number of responses required for the feed
+    /// Minimum number of responses required for the feed, unscaled
     pub min_responses: u32,
 }
 

--- a/surge/switchboard-surge-core/src/feed_metadata.rs
+++ b/surge/switchboard-surge-core/src/feed_metadata.rs
@@ -84,7 +84,7 @@ pub fn get_or_create_feed_metadata(
         jobs: vec![oracle_job.clone()],
         min_job_responses: Some(STREAMING_MIN_RESPONSES),
         min_oracle_samples: Some(STREAMING_MIN_ORACLE_SAMPLES),
-        max_job_range_pct: Some(1), // 100% range for streaming
+        max_job_range_pct: Some(1), // Single-job streaming feed; raw v2 percent uses 1e9 scale.
     };
     
     // Encode to base64


### PR DESCRIPTION
## Summary

- Clarify SDK README guidance for raw v2 feed parameters, SDK helper `maxVariance`, quorum fields, and value scaling.
- Update JS/TS JSDoc and Rustdoc comments so helper-level `maxVariance` and raw scaled fields are not confused.
- Add comments to Aptos example scripts and Surge metadata code where `maxVariance` / `max_job_range_pct` values appear.

## Why

The same concept is exposed through multiple surfaces with different units. SDK helpers may accept human percentages and scale internally, while raw gateway and v2 feed fields expect `1e9`-scaled integers.

## Validation

- Ran the user-docs boundary scanner on touched README files.
- Ran a search audit for `maxJobRangePct|max_job_range_pct|maxVariance|max_variance|max_range_percent|minJobResponses|minOracleSamples|RangeExceeded`.
- Ran `git diff --check`.
- TypeScript checks were not run because `codex-in-container` could not start Colima: `ha.sock ... connection refused` before entering the container.