### PR TITLE
Add alignment-agnostic parse functions

### DIFF
--- a/solana/rust/switchboard-on-demand-client/src/accounts/pull_feed.rs
+++ b/solana/rust/switchboard-on-demand-client/src/accounts/pull_feed.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use anyhow_ext::anyhow;
 use anyhow_ext::Context;
 use bytemuck;
 use rust_decimal::Decimal;
@@ -134,6 +135,36 @@ impl OracleSubmission {
 }
 
 impl PullFeedAccountData {
+    /// Anchor account discriminator (`sha256("account:PullFeedAccountData")[..8]`).
+    const DISCRIMINATOR: [u8; 8] = [196, 27, 108, 196, 10, 215, 219, 40];
+
+    /// Parses pull feed account data from raw bytes into an owned value, with no alignment requirement.
+    pub fn parse_unaligned(data: &[u8]) -> Result<Self, AnyhowError> {
+        if data.len() < Self::DISCRIMINATOR.len() {
+            return Err(anyhow!(
+                "PullFeedAccountData::parse_unaligned: missing discriminator"
+            ));
+        }
+
+        let mut disc_bytes = [0u8; 8];
+        disc_bytes.copy_from_slice(&data[..8]);
+        if disc_bytes != Self::DISCRIMINATOR {
+            return Err(anyhow!(
+                "PullFeedAccountData::parse_unaligned: invalid discriminator"
+            ));
+        }
+
+        let expected_size = std::mem::size_of::<Self>() + 8;
+        if data.len() < expected_size {
+            return Err(anyhow!(
+                "PullFeedAccountData::parse_unaligned: data too small"
+            ));
+        }
+
+        bytemuck::try_pod_read_unaligned::<Self>(&data[8..expected_size])
+            .map_err(|_| anyhow!("PullFeedAccountData::parse_unaligned: failed to parse data"))
+    }
+
     /// The median value of the submissions needed for quorom size
     pub fn value(&self) -> Decimal {
         self.result.value()

--- a/solana/rust/switchboard-on-demand-client/src/pull_feed.rs
+++ b/solana/rust/switchboard-on-demand-client/src/pull_feed.rs
@@ -156,10 +156,8 @@ impl PullFeed {
             .get_account_data(key)
             .await
             .map_err(|_| anyhow!("PullFeed.load_data: Account not found"))?;
-        let account = account[8..].to_vec();
-        let data = bytemuck::try_from_bytes::<PullFeedAccountData>(&account)
-            .map_err(|_| anyhow!("PullFeed.load_data: Failed to parse data"))?;
-        Ok(*data)
+        PullFeedAccountData::parse_unaligned(&account)
+            .context("PullFeed.load_data: Failed to parse data")
     }
 
     fn get_solana_submit_signatures_ix(

--- a/solana/rust/switchboard-on-demand/src/client/pull_feed.rs
+++ b/solana/rust/switchboard-on-demand/src/client/pull_feed.rs
@@ -157,10 +157,8 @@ impl PullFeed {
             .get_account_data(&key.to_bytes().into())
             .await
             .map_err(|_| anyhow!("PullFeed.load_data: Account not found"))?;
-        let account = account[8..].to_vec();
-        let data = bytemuck::try_from_bytes::<PullFeedAccountData>(&account)
-            .map_err(|_| anyhow!("PullFeed.load_data: Failed to parse data"))?;
-        Ok(*data)
+        PullFeedAccountData::parse_unaligned(&account)
+            .map_err(|_| anyhow!("PullFeed.load_data: Failed to parse data"))
     }
 
     fn get_solana_submit_signatures_ix(

--- a/solana/rust/switchboard-on-demand/src/on_demand/accounts/pull_feed.rs
+++ b/solana/rust/switchboard-on-demand/src/on_demand/accounts/pull_feed.rs
@@ -302,6 +302,27 @@ impl PullFeedAccountData {
         }
     }
 
+    /// Parses pull feed account data from raw bytes into an owned value, with no alignment requirement.
+    pub fn parse_unaligned(data: &[u8]) -> Result<Self, OnDemandError> {
+        if data.len() < Self::DISCRIMINATOR.len() {
+            return Err(OnDemandError::InvalidDiscriminator);
+        }
+
+        let mut disc_bytes = [0u8; 8];
+        disc_bytes.copy_from_slice(&data[..8]);
+        if disc_bytes != Self::DISCRIMINATOR {
+            return Err(OnDemandError::InvalidDiscriminator);
+        }
+
+        let expected_size = std::mem::size_of::<Self>() + 8;
+        if data.len() < expected_size {
+            return Err(OnDemandError::InvalidData);
+        }
+
+        bytemuck::try_pod_read_unaligned::<Self>(&data[8..expected_size])
+            .map_err(|_| OnDemandError::AccountDeserializeError)
+    }
+
     /// Generate a checksum for the given feed hash, result, slothash, max_variance and min_responses
     /// This is signed by the oracle and used to verify that the data submitted by the oracles is valid.
     pub fn generate_checksum(&self, result: i128, slothash: [u8; 32]) -> [u8; 32] {


### PR DESCRIPTION
## Summary 
  
`PullFeedAccountData::parse` is zero-copy: it validates the bytes with `bytemuck::try_from_bytes` and returns a `Ref` that points directly at the account data. Because the cast is performed in place, the bytes must sit at an address aligned to the struct's alignment. The struct contains `i128` fields, so on host targets its alignment is 16. (Under SBF, `i128` is 8-aligned, so on-chain `parse` is unaffected; this is an off-chain-only problem.)
  
Off-chain consumers read the struct just past Anchor's 8-byte discriminator, at `buffer + 8`. Given a typical 16-aligned buffer, `buffer + 8` is only 8-aligned, so `parse`  (and any direct `try_from_bytes` cast) fails with an alignment error on otherwise-valid  data. Today this is worked around by copying the post-discriminator bytes into a fresh `Vec` purely to obtain an aligned buffer.
 
This PR adds `PullFeedAccountData::parse_unaligned`: it runs the same discriminator and length validation, but returns an owned `PullFeedAccountData` via `bytemuck::try_pod_read_unaligned`, which copies into properly-aligned memory and therefore succeeds at any input alignment.